### PR TITLE
Use go version from go.mod for GHA CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version-file: go.mod
       - run: mkdir build
       - run: go build -trimpath -o build/lk-jwt-service_${{ matrix.os }}_${{ matrix.arch }} ./main.go
         env:


### PR DESCRIPTION
So that we use consistent version in CI.