### PR TITLE
Use version of go specified in go.mod when building the docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,7 +2,6 @@ name: Build and publish Docker image
 
 on:
   push:
-    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -50,7 +49,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{github.ref == 'refs/heads/main'}} # only push on main branch
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -53,3 +53,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GO_VERSION=$(go mod edit -json | jq -r .Go)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@0f069ddc17b8eb78586b08a7fe335fd54649e2d3
 
+      - name: Get go version
+        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -53,4 +56,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GO_VERSION=$(go mod edit -json | jq -r .Go)
+            GO_VERSION=${{ env.GO_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG GO_VERSION
+ARG GO_VERSION="build-arg-must-be-provided"
 
-FROM golang:${GO_VERSION}-alpine as builder
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.23-alpine as builder
+ARG GO_VERSION
+
+FROM golang:${GO_VERSION}-alpine as builder
 
 WORKDIR /proj
 


### PR DESCRIPTION
So that they are kept in sync...

I *think* this will work, but probably need to just merge it and debug on `main` if necessary.