### PR TITLE
Dockerfile: provide sane default for `GO_VERSION` build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION="build-arg-must-be-provided"
+ARG GO_VERSION="1"
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder
 


### PR DESCRIPTION
Fixes #79.