### PR TITLE
Document where go version comes from in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Set the version to match that which is in go.mod
 ARG GO_VERSION="build-arg-must-be-provided"
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder


### PR DESCRIPTION
Fixes #79

n.b. this is done automatically in CI by https://github.com/element-hq/lk-jwt-service/blob/d24adff44a15b3db5c3d2bb3178f26fc38c16492/.github/workflows/docker.yaml#L47-L48