### PR TITLE
Fix DNS resolution with host aliases  + Fix TLS Verifiy on default transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,15 @@ COPY *.go ./
 
 ARG TARGETOS TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o lk-jwt-service
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.24.0/src/net/conf.go#L343
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM scratch
 
 COPY --from=builder /proj/lk-jwt-service /lk-jwt-service
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
 
 EXPOSE 8080
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"crypto/tls"
 
 	"time"
 
@@ -64,6 +65,8 @@ func exchangeOIDCToken(
 
 	if skipVerifyTLS {
 		log.Printf("!!! WARNING !!! Skipping TLS verification for matrix client connection to %s", token.MatrixServerName)
+		// Disable TLS verification on the default HTTP Transport for the well-known lookup
+		http.DefaultTransport.(*http.Transport).TLSClientConfig  = &tls.Config{ InsecureSkipVerify: true }
 	}
 	client := fclient.NewClient(fclient.WithWellKnownSRVLookups(true), fclient.WithSkipVerify(skipVerifyTLS))
 


### PR DESCRIPTION
See related issues : 
- https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
- https://github.com/golang/go/issues/35305

At the moment, Go tries to solve using Go DNS lib and ignores /etc/hosts if nsswitch is absent

Required to pass CI tests of Matrix RTC Backend in [ess-helm](https://github.com/element-hq/ess-helm/pull/343)