### PR TITLE
fix: add `expires_in` field to `OpenIDTokenType`

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type OpenIDTokenType struct {
 	AccessToken      string `json:"access_token"`
 	TokenType        string `json:"token_type"`
 	MatrixServerName string `json:"matrix_server_name"`
+	ExpiresIn        int    `json:"expires_in"`
 }
 
 type LegacySFURequest struct {

--- a/main_test.go
+++ b/main_test.go
@@ -145,6 +145,7 @@ func TestHandlePost(t *testing.T) {
 			"access_token":       "testAccessToken",
 			"token_type":         "testTokenType",
 			"matrix_server_name": u.Host,
+			"expires_in":         3600,
 		},
 		"member": map[string]interface{}{
 			"id":                "member_test_id",
@@ -253,6 +254,7 @@ func TestLegacyHandlePost(t *testing.T) {
 			"access_token":       "testAccessToken",
 			"token_type":         "testTokenType",
 			"matrix_server_name": u.Host,
+			"expires_in":         3600,
 		},
 		"device_id": "testDevice",
 	}
@@ -650,7 +652,8 @@ func TestMapSFURequest(t *testing.T) {
                 "openid_token": {
                     "access_token": "test_token",
                     "token_type": "Bearer",
-                    "matrix_server_name": "example.com"
+                    "matrix_server_name": "example.com",
+                    "expires_in": 3600
                 },
                 "device_id": "testDevice"
             }`,
@@ -660,6 +663,7 @@ func TestMapSFURequest(t *testing.T) {
                     AccessToken:      "test_token",
                     TokenType:        "Bearer",
                     MatrixServerName: "example.com",
+                    ExpiresIn:        3600,
                 },
                 DeviceID: "testDevice",
             },
@@ -672,7 +676,8 @@ func TestMapSFURequest(t *testing.T) {
                 "openid_token": {
                     "access_token": "test_token",
                     "token_type": "Bearer",
-                    "matrix_server_name": "example.com"
+                    "matrix_server_name": "example.com",
+                    "expires_in": 3600
                 },
                 "member": {
                     "id": "test_id",
@@ -687,6 +692,7 @@ func TestMapSFURequest(t *testing.T) {
                     AccessToken:      "test_token",
                     TokenType:        "Bearer",
                     MatrixServerName: "example.com",
+                    ExpiresIn:        3600,
                 },
                 Member: MatrixRTCMemberType{
                     ID:              "test_id",
@@ -714,7 +720,8 @@ func TestMapSFURequest(t *testing.T) {
                 "openid_token": {
                     "access_token": "test_token",
                     "token_type": "Bearer",
-                    "matrix_server_name": "example.com"
+                    "matrix_server_name": "example.com",
+                    "expires_in": 3600
                 },
                 "device_id": "testDevice",
                 "extra_field": "should_fail"
@@ -785,7 +792,8 @@ func TestMapSFURequestMemoryLeak(t *testing.T) {
 		"openid_token": {
 			"access_token": "test_token",
 			"token_type": "Bearer",
-			"matrix_server_name": "example.com"
+			"matrix_server_name": "example.com",
+			"expires_in": 3600
 		},
 		"member": {
 			"id": "test_id",


### PR DESCRIPTION
As we enforcing `DisallowUnknownFields()` while checking JSON input we need to add all required fields to `OpenIDTokenType` such as `expires_in`.