### PR TITLE
Add Environment Variable USER_INFO_HOST_OVERRIDE to bypass server delegation issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Set the version to match that which is in go.mod
 ARG GO_VERSION="1.23.0"
 
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder
+FROM --platform=linux/amd64 golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the version to match that which is in go.mod
-ARG GO_VERSION="build-arg-must-be-provided"
+ARG GO_VERSION="1.23.0"
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the version to match that which is in go.mod
-ARG GO_VERSION="1.23.0"
+ARG GO_VERSION="build-arg-must-be-provided"
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Set the version to match that which is in go.mod
 ARG GO_VERSION="1.23.0"
 
-FROM --platform=linux/amd64 golang:${GO_VERSION}-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /proj
 

--- a/main.go
+++ b/main.go
@@ -181,8 +181,13 @@ var exchangeOpenIdUserInfo = func(
 	client := fclient.NewClient(fclient.WithWellKnownSRVLookups(true), fclient.WithSkipVerify(skipVerifyTLS))
 
 	// validate the openid token by getting the user's ID
+	hostOverride := os.Getenv("USER_INFO_HOST_OVERRIDE")
+	serverName := spec.ServerName(token.MatrixServerName)
+	if hostOverride != "" {
+		serverName = spec.ServerName(hostOverride)
+	}
 	userinfo, err := client.LookupUserInfo(
-		ctx, spec.ServerName(token.MatrixServerName), token.AccessToken,
+		ctx, serverName, token.AccessToken,
 	)
 	if err != nil {
 		log.Printf("Failed to look up user info: %v", err)


### PR DESCRIPTION
I added a new environment Variable to temporarily fix #122. I also added a bypass for the error `userID doesn't match server name` as this is obviously violated when you change the `serverName`.