### PR TITLE
Dockerfile: add basic docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,12 @@ FROM scratch
 COPY --from=builder /proj/lk-jwt-service /lk-jwt-service
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
+# needed for health check below:
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=builder /bin/busybox /wget
 
 EXPOSE 8080
 
 CMD [ "/lk-jwt-service" ]
+
+HEALTHCHECK --start-period=15s --start-interval=5s CMD ["/wget", "--spider", "http://localhost:8080/healthz"]


### PR DESCRIPTION
This makes use of the busybox binary provided by the builder image. A shorter than usual startup period is declared, because the service will start very quickly.

Implements #81.