### PR TITLE
feat: add the `LIVEKIT_JWT_NETWORK_TYPE` config to allow binding to a unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Set environment variables to configure the service:
 | `LIVEKIT_JWT_BIND`                            | Address to bind the server to                                 | ❌ No, ⚠️ mutually exclusive with `LIVEKIT_JWT_PORT` | `:8080` |
 | `LIVEKIT_JWT_PORT`                            | ⚠️ Deprecated Port to bind the server to                      | ❌ No, ⚠️ mutually exclusive with `LIVEKIT_JWT_BIND` |         |
 | `LIVEKIT_FULL_ACCESS_HOMESERVERS`             | Comma-separated list of full-access homeservers (`*` for all) | ❌ No                                                | `*`     |
+| `LIVEKIT_JWT_NETWORK`                         | The kind of network socket we will be listening on (`tcp` for regular http, or `unix` for listening on a unix socket) | ❌ No                                                | `tcp`   |
 
 > [!IMPORTANT]
 > By default, the LiveKit SFU auto-creates rooms for all users. To ensure proper

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Set environment variables to configure the service:
 | `LIVEKIT_JWT_BIND`                            | Address to bind the server to                                 | ❌ No, ⚠️ mutually exclusive with `LIVEKIT_JWT_PORT` | `:8080` |
 | `LIVEKIT_JWT_PORT`                            | ⚠️ Deprecated Port to bind the server to                      | ❌ No, ⚠️ mutually exclusive with `LIVEKIT_JWT_BIND` |         |
 | `LIVEKIT_FULL_ACCESS_HOMESERVERS`             | Comma-separated list of full-access homeservers (`*` for all) | ❌ No                                                | `*`     |
-| `LIVEKIT_JWT_NETWORK`                         | The kind of network socket we will be listening on (`tcp` for regular http, or `unix` for listening on a unix socket) | ❌ No                                                | `tcp`   |
+| `LIVEKIT_JWT_NETWORK_TYPE`                         | The kind of network socket we will be listening on (`tcp` for regular http, or `unix` for listening on a unix socket) | ❌ No                                                | `tcp`   |
 
 > [!IMPORTANT]
 > By default, the LiveKit SFU auto-creates rooms for all users. To ensure proper

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"slices"
@@ -43,7 +44,8 @@ type Config struct {
 	LkUrl                 string
 	SkipVerifyTLS         bool
 	FullAccessHomeservers []string
-	LkJwtBind               string
+	LkJwtBind             string
+	lkJwtNetworkType      string
 }
 type MatrixRTCMemberType struct {
 	ID              string `json:"id"`
@@ -78,75 +80,75 @@ type SFUResponse struct {
 
 type MatrixErrorResponse struct {
 	Status  int
-	ErrCode string 
+	ErrCode string
 	Err     string
 }
 
 type ValidatableSFURequest interface {
-    Validate() error
+	Validate() error
 }
 
 var unpaddedBase64 = base64.StdEncoding.WithPadding(base64.NoPadding)
 
-func (e *MatrixErrorResponse) Error() string { 
-    return e.Err
+func (e *MatrixErrorResponse) Error() string {
+	return e.Err
 }
 
 func (r *SFURequest) Validate() error {
-    if r.RoomID == "" || r.SlotID == "" {
+	if r.RoomID == "" || r.SlotID == "" {
 		log.Printf("Missing room_id or slot_id: room_id='%s', slot_id='%s'", r.RoomID, r.SlotID)
-        return &MatrixErrorResponse{
-            Status:  http.StatusBadRequest,
-            ErrCode: "M_BAD_JSON",
-            Err:     "The request body is missing `room_id` or `slot_id`",
-        }
-    }
-    if r.Member.ID == "" || r.Member.ClaimedUserID == "" || r.Member.ClaimedDeviceID == "" {
-        log.Printf("Missing member parameters: %+v", r.Member)
-        return &MatrixErrorResponse{
-            Status:  http.StatusBadRequest,
-            ErrCode: "M_BAD_JSON",
-            Err:     "The request body `member` is missing a `id`, `claimed_user_id` or `claimed_device_id`",
-        }
-    }
-    if r.OpenIDToken.AccessToken == "" || r.OpenIDToken.MatrixServerName == "" {
+		return &MatrixErrorResponse{
+			Status:  http.StatusBadRequest,
+			ErrCode: "M_BAD_JSON",
+			Err:     "The request body is missing `room_id` or `slot_id`",
+		}
+	}
+	if r.Member.ID == "" || r.Member.ClaimedUserID == "" || r.Member.ClaimedDeviceID == "" {
+		log.Printf("Missing member parameters: %+v", r.Member)
+		return &MatrixErrorResponse{
+			Status:  http.StatusBadRequest,
+			ErrCode: "M_BAD_JSON",
+			Err:     "The request body `member` is missing a `id`, `claimed_user_id` or `claimed_device_id`",
+		}
+	}
+	if r.OpenIDToken.AccessToken == "" || r.OpenIDToken.MatrixServerName == "" {
 		log.Printf("Missing OpenID token parameters: %+v", r.OpenIDToken)
-        return &MatrixErrorResponse{
-            Status:  http.StatusBadRequest,
-            ErrCode: "M_BAD_JSON",
-            Err:     "The request body `openid_token` is missing a `access_token` or `matrix_server_name`",
-        }
-    }
-    return nil
+		return &MatrixErrorResponse{
+			Status:  http.StatusBadRequest,
+			ErrCode: "M_BAD_JSON",
+			Err:     "The request body `openid_token` is missing a `access_token` or `matrix_server_name`",
+		}
+	}
+	return nil
 }
 
 func (r *LegacySFURequest) Validate() error {
-    if r.Room == "" {
-        return &MatrixErrorResponse{
-            Status:  http.StatusBadRequest,
-            ErrCode: "M_BAD_JSON",
-            Err:     "Missing room parameter",
-        }
-    }
-    if r.OpenIDToken.AccessToken == "" || r.OpenIDToken.MatrixServerName == "" {
-        return &MatrixErrorResponse{
-            Status:  http.StatusBadRequest,
-            ErrCode: "M_BAD_JSON",
-            Err:     "Missing OpenID token parameters",
-        }
-    }
-    return nil
+	if r.Room == "" {
+		return &MatrixErrorResponse{
+			Status:  http.StatusBadRequest,
+			ErrCode: "M_BAD_JSON",
+			Err:     "Missing room parameter",
+		}
+	}
+	if r.OpenIDToken.AccessToken == "" || r.OpenIDToken.MatrixServerName == "" {
+		return &MatrixErrorResponse{
+			Status:  http.StatusBadRequest,
+			ErrCode: "M_BAD_JSON",
+			Err:     "Missing OpenID token parameters",
+		}
+	}
+	return nil
 }
 
 // writeMatrixError writes a Matrix-style error response to the HTTP response writer.
 func writeMatrixError(w http.ResponseWriter, status int, errCode string, errMsg string) {
-    w.WriteHeader(status)
-    if err := json.NewEncoder(w).Encode(gomatrix.RespError{
-        ErrCode: errCode,
-        Err:     errMsg,
-    }); err != nil {
-        log.Printf("failed to encode json error message! %v", err)
-    }
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(gomatrix.RespError{
+		ErrCode: errCode,
+		Err:     errMsg,
+	}); err != nil {
+		log.Printf("failed to encode json error message! %v", err)
+	}
 }
 
 func getJoinToken(apiKey, apiSecret, room, identity string) (string, error) {
@@ -206,156 +208,156 @@ func (h *Handler) isFullAccessUser(matrixServerName string) bool {
 
 func (h *Handler) processLegacySFURequest(r *http.Request, req *LegacySFURequest) (*SFUResponse, error) {
 	// Note LegacySFURequest has already been validated at this point
-	
-    userInfo, err := exchangeOpenIdUserInfo(r.Context(), req.OpenIDToken, h.skipVerifyTLS)
-    if err != nil {
+
+	userInfo, err := exchangeOpenIdUserInfo(r.Context(), req.OpenIDToken, h.skipVerifyTLS)
+	if err != nil {
 		return nil, &MatrixErrorResponse{
-			Status: http.StatusInternalServerError,
+			Status:  http.StatusInternalServerError,
 			ErrCode: "M_LOOKUP_FAILED",
-			Err: "Failed to look up user info from homeserver",
+			Err:     "Failed to look up user info from homeserver",
 		}
-    }
+	}
 
-    isFullAccessUser := h.isFullAccessUser(req.OpenIDToken.MatrixServerName)
+	isFullAccessUser := h.isFullAccessUser(req.OpenIDToken.MatrixServerName)
 
-    log.Printf(
-        "Got Matrix user info for %s (%s)",
-        userInfo.Sub,
-        map[bool]string{true: "full access", false: "restricted access"}[isFullAccessUser],
-    )
+	log.Printf(
+		"Got Matrix user info for %s (%s)",
+		userInfo.Sub,
+		map[bool]string{true: "full access", false: "restricted access"}[isFullAccessUser],
+	)
 
-    // TODO: is DeviceID required? If so then we should have validated at the start
-    lkIdentity := userInfo.Sub + ":" + req.DeviceID
-    
-	// We can hard-code the slotId since for the m.call application only the m.call#ROOM slot is defined. 
-	// This ensures that the same LiveKit room alias being derived for the same Matrix room for both the 
-	// LegacySFURequest (/sfu/get endpoint) and the SFURequest (/get_token endpoint). 
-    // 
-	// Note a mismatch between the legacy livekit_alias (which is the Matrix roomId) field in the MatrixRTC 
-	// membership state event and the actual lkRoomAlias (as derived below and used on the SFU) which is 
+	// TODO: is DeviceID required? If so then we should have validated at the start
+	lkIdentity := userInfo.Sub + ":" + req.DeviceID
+
+	// We can hard-code the slotId since for the m.call application only the m.call#ROOM slot is defined.
+	// This ensures that the same LiveKit room alias being derived for the same Matrix room for both the
+	// LegacySFURequest (/sfu/get endpoint) and the SFURequest (/get_token endpoint).
+	//
+	// Note a mismatch between the legacy livekit_alias (which is the Matrix roomId) field in the MatrixRTC
+	// membership state event and the actual lkRoomAlias (as derived below and used on the SFU) which is
 	// part of the LiveKit JWT Token does in general NOT confuse clients as the JWT token is passed as is
 	// to the livekit-client SDK.
-	// 
-    // This change ensures compatibility with clients using pseudonymous livekit_aliases.
-    slotId := "m.call#ROOM"
-    lkRoomAliasHash := sha256.Sum256([]byte(req.Room + "|" + slotId))
-    lkRoomAlias := unpaddedBase64.EncodeToString(lkRoomAliasHash[:])
-    token, err := getJoinToken(h.key, h.secret, lkRoomAlias, lkIdentity)
-    if err != nil {
+	//
+	// This change ensures compatibility with clients using pseudonymous livekit_aliases.
+	slotId := "m.call#ROOM"
+	lkRoomAliasHash := sha256.Sum256([]byte(req.Room + "|" + slotId))
+	lkRoomAlias := unpaddedBase64.EncodeToString(lkRoomAliasHash[:])
+	token, err := getJoinToken(h.key, h.secret, lkRoomAlias, lkIdentity)
+	if err != nil {
 		return nil, &MatrixErrorResponse{
-			Status: http.StatusInternalServerError,
+			Status:  http.StatusInternalServerError,
 			ErrCode: "M_UNKNOWN",
-			Err: "Internal Server Error",
+			Err:     "Internal Server Error",
 		}
-    }
+	}
 
-    if isFullAccessUser {
-        if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
+	if isFullAccessUser {
+		if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
 			return nil, &MatrixErrorResponse{
-				Status: http.StatusInternalServerError,
+				Status:  http.StatusInternalServerError,
 				ErrCode: "M_UNKNOWN",
-				Err: "Unable to create room on SFU",
+				Err:     "Unable to create room on SFU",
 			}
-        }
-    }
+		}
+	}
 
-    return &SFUResponse{URL: h.lkUrl, JWT: token}, nil
+	return &SFUResponse{URL: h.lkUrl, JWT: token}, nil
 }
 
 func (h *Handler) processSFURequest(r *http.Request, req *SFURequest) (*SFUResponse, error) {
 	// Note SFURequest has already been validated at this point
-	
-    userInfo, err := exchangeOpenIdUserInfo(r.Context(), req.OpenIDToken, h.skipVerifyTLS)
-    if err != nil {
+
+	userInfo, err := exchangeOpenIdUserInfo(r.Context(), req.OpenIDToken, h.skipVerifyTLS)
+	if err != nil {
 		return nil, &MatrixErrorResponse{
-			Status: http.StatusUnauthorized,
+			Status:  http.StatusUnauthorized,
 			ErrCode: "M_UNAUTHORIZED",
-			Err: "The request could not be authorised.",
+			Err:     "The request could not be authorised.",
 		}
-    }
+	}
 
 	// Check if validated userInfo.Sub matches req.Member.ClaimedUserID
 	if req.Member.ClaimedUserID != userInfo.Sub {
 		log.Printf("Claimed user ID %s does not match token subject %s", req.Member.ClaimedUserID, userInfo.Sub)
 		return nil, &MatrixErrorResponse{
-			Status: http.StatusUnauthorized,
+			Status:  http.StatusUnauthorized,
 			ErrCode: "M_UNAUTHORIZED",
-			Err: "The request could not be authorised.",
+			Err:     "The request could not be authorised.",
 		}
 	}
 
 	// Does the user belong to homeservers granted full access
-    isFullAccessUser := h.isFullAccessUser(req.OpenIDToken.MatrixServerName)
+	isFullAccessUser := h.isFullAccessUser(req.OpenIDToken.MatrixServerName)
 
-    log.Printf(
-        "Got Matrix user info for %s (%s)",
-        userInfo.Sub,
-        map[bool]string{true: "full access", false: "restricted access"}[isFullAccessUser],
-    )
+	log.Printf(
+		"Got Matrix user info for %s (%s)",
+		userInfo.Sub,
+		map[bool]string{true: "full access", false: "restricted access"}[isFullAccessUser],
+	)
 
 	lkIdentityRaw := userInfo.Sub + "|" + req.Member.ClaimedDeviceID + "|" + req.Member.ID
 	lkIdentityHash := sha256.Sum256([]byte(lkIdentityRaw))
 	lkIdentity := unpaddedBase64.EncodeToString(lkIdentityHash[:])
 
-    lkRoomAliasHash := sha256.Sum256([]byte(req.RoomID + "|" + req.SlotID))
+	lkRoomAliasHash := sha256.Sum256([]byte(req.RoomID + "|" + req.SlotID))
 	lkRoomAlias := unpaddedBase64.EncodeToString(lkRoomAliasHash[:])
 
-    token, err := getJoinToken(h.key, h.secret, lkRoomAlias, lkIdentity)
-    if err != nil {
+	token, err := getJoinToken(h.key, h.secret, lkRoomAlias, lkIdentity)
+	if err != nil {
 		log.Printf("Error getting LiveKit token: %v", err)
 		return nil, &MatrixErrorResponse{
-			Status: http.StatusInternalServerError,
+			Status:  http.StatusInternalServerError,
 			ErrCode: "M_UNKNOWN",
-			Err: "Internal Server Error",
+			Err:     "Internal Server Error",
 		}
-    }
+	}
 
-    if isFullAccessUser {
-        if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
+	if isFullAccessUser {
+		if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
 			return nil, &MatrixErrorResponse{
-				Status: http.StatusInternalServerError,
+				Status:  http.StatusInternalServerError,
 				ErrCode: "M_UNKNOWN",
-				Err: "Unable to create room on SFU",
+				Err:     "Unable to create room on SFU",
 			}
-        }
-    }
+		}
+	}
 
-    return &SFUResponse{URL: h.lkUrl, JWT: token}, nil
+	return &SFUResponse{URL: h.lkUrl, JWT: token}, nil
 }
 
 var createLiveKitRoom = func(ctx context.Context, h *Handler, room, matrixUser, lkIdentity string) error {
-    roomClient := lksdk.NewRoomServiceClient(h.lkUrl, h.key, h.secret)
-    creationStart := time.Now().Unix()
-    lkRoom, err := roomClient.CreateRoom(
-        ctx,
-        &livekit.CreateRoomRequest{
-            Name:             room,
-            EmptyTimeout:     5 * 60, // 5 Minutes to keep the room open if no one joins
-            DepartureTimeout: 20,     // number of seconds to keep the room after everyone leaves
-            MaxParticipants:  0,      // 0 == no limitation
-        },
-    )
+	roomClient := lksdk.NewRoomServiceClient(h.lkUrl, h.key, h.secret)
+	creationStart := time.Now().Unix()
+	lkRoom, err := roomClient.CreateRoom(
+		ctx,
+		&livekit.CreateRoomRequest{
+			Name:             room,
+			EmptyTimeout:     5 * 60, // 5 Minutes to keep the room open if no one joins
+			DepartureTimeout: 20,     // number of seconds to keep the room after everyone leaves
+			MaxParticipants:  0,      // 0 == no limitation
+		},
+	)
 
-    if err != nil {
-        return fmt.Errorf("unable to create room %s: %w", room, err)
-    }
+	if err != nil {
+		return fmt.Errorf("unable to create room %s: %w", room, err)
+	}
 
-    // Log the room creation time and the user info
-    isNewRoom := lkRoom.GetCreationTime() >= creationStart && lkRoom.GetCreationTime() <= time.Now().Unix()
-    log.Printf(
-        "%s LiveKit room sid: %s (alias: %s) for full-access Matrix user %s (LiveKit identity: %s)",
-        map[bool]string{true: "Created", false: "Using"}[isNewRoom],
-        lkRoom.Sid, room, matrixUser, lkIdentity,
-    )
+	// Log the room creation time and the user info
+	isNewRoom := lkRoom.GetCreationTime() >= creationStart && lkRoom.GetCreationTime() <= time.Now().Unix()
+	log.Printf(
+		"%s LiveKit room sid: %s (alias: %s) for full-access Matrix user %s (LiveKit identity: %s)",
+		map[bool]string{true: "Created", false: "Using"}[isNewRoom],
+		lkRoom.Sid, room, matrixUser, lkIdentity,
+	)
 
-    return nil
+	return nil
 }
 
 func (h *Handler) prepareMux() *http.ServeMux {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sfu/get", h.handle_legacy) // TODO: This is deprecated and will be removed in future versions
- 	mux.HandleFunc("/get_token", h.handle)
+	mux.HandleFunc("/get_token", h.handle)
 	mux.HandleFunc("/healthz", h.healthcheck)
 
 	return mux
@@ -379,17 +381,17 @@ func mapSFURequest(data *[]byte) (any, error) {
 		decoder := json.NewDecoder(strings.NewReader(string(*data)))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(req); err == nil {
-            if err := req.Validate(); err != nil {
-                return nil, err
-            }			
+			if err := req.Validate(); err != nil {
+				return nil, err
+			}
 			return req, nil
 		}
 	}
 
 	return nil, &MatrixErrorResponse{
-		Status: http.StatusBadRequest,
+		Status:  http.StatusBadRequest,
 		ErrCode: "M_BAD_JSON",
-		Err: "The request body was malformed, missing required fields, or contained invalid values (e.g. missing `room_id`, `slot_id`, or `openid_token`).",
+		Err:     "The request body was malformed, missing required fields, or contained invalid values (e.g. missing `room_id`, `slot_id`, or `openid_token`).",
 	}
 }
 
@@ -429,7 +431,7 @@ func (h *Handler) handle_legacy(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		
+
 		switch sfuReq := sfuAccessRequest.(type) {
 		case *SFURequest:
 			log.Printf("Processing SFU request")
@@ -486,10 +488,10 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else {
-            log.Printf("Error reading request body: %v", err)
-            writeMatrixError(w, http.StatusBadRequest, "M_NOT_JSON", "Error reading request")
-            return
-        }			
+			log.Printf("Error reading request body: %v", err)
+			writeMatrixError(w, http.StatusBadRequest, "M_NOT_JSON", "Error reading request")
+			return
+		}
 
 		log.Printf("Processing SFU request")
 		sfuAccessResponse, err := h.processSFURequest(r, &sfuAccessRequest)
@@ -607,6 +609,11 @@ func parseConfig() (*Config, error) {
 		return nil, fmt.Errorf("LIVEKIT_JWT_BIND and LIVEKIT_JWT_PORT environment variables MUST NOT be set together")
 	}
 
+	lkJwtNetworkType := os.Getenv("LIVEKIT_JWT_NETWORK_TYPE")
+	if lkJwtNetworkType == "" {
+		lkJwtNetworkType = "tcp"
+	}
+
 	return &Config{
 		Key:                   key,
 		Secret:                secret,
@@ -614,6 +621,7 @@ func parseConfig() (*Config, error) {
 		SkipVerifyTLS:         skipVerifyTLS,
 		FullAccessHomeservers: strings.Fields(strings.ReplaceAll(fullAccessHomeservers, ",", " ")),
 		LkJwtBind:             lkJwtBind,
+		lkJwtNetworkType:      lkJwtNetworkType,
 	}, nil
 }
 
@@ -634,5 +642,10 @@ func main() {
 		fullAccessHomeservers: config.FullAccessHomeservers,
 	}
 
-	log.Fatal(http.ListenAndServe(config.LkJwtBind, handler.prepareMux()))
+	listener, err := net.Listen(config.lkJwtNetworkType, config.LkJwtBind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Fatal(http.Serve(listener, handler.prepareMux()))
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ type Config struct {
 	SkipVerifyTLS         bool
 	FullAccessHomeservers []string
 	LkJwtBind             string
-	lkJwtNetworkType      string
+	LkJwtNetworkType      string
 }
 type MatrixRTCMemberType struct {
 	ID              string `json:"id"`
@@ -621,7 +621,7 @@ func parseConfig() (*Config, error) {
 		SkipVerifyTLS:         skipVerifyTLS,
 		FullAccessHomeservers: strings.Fields(strings.ReplaceAll(fullAccessHomeservers, ",", " ")),
 		LkJwtBind:             lkJwtBind,
-		lkJwtNetworkType:      lkJwtNetworkType,
+		LkJwtNetworkType:      lkJwtNetworkType,
 	}, nil
 }
 
@@ -642,7 +642,7 @@ func main() {
 		fullAccessHomeservers: config.FullAccessHomeservers,
 	}
 
-	listener, err := net.Listen(config.lkJwtNetworkType, config.LkJwtBind)
+	listener, err := net.Listen(config.LkJwtNetworkType, config.LkJwtBind)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -108,7 +108,7 @@ func TestHandlePost(t *testing.T) {
 		key:                   "testKey",
 		lkUrl:                 "wss://lk.local:8080/foo",
 		fullAccessHomeservers: []string{"example.com"},
-		skipVerifyTLS:     true,
+		skipVerifyTLS:         true,
 	}
 
 	var matrixServerName = ""
@@ -157,62 +157,62 @@ func TestHandlePost(t *testing.T) {
 	jsonBody, _ := json.Marshal(testCase)
 
 	req, err := http.NewRequest("POST", "/get_token", bytes.NewBuffer(jsonBody))
-		if err != nil {
-			t.Fatal(err)
-		}
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		rr := httptest.NewRecorder()
-		handler.prepareMux().ServeHTTP(rr, req)
+	rr := httptest.NewRecorder()
+	handler.prepareMux().ServeHTTP(rr, req)
 
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
-		}
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
 
-		if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
-			t.Errorf("handler returned wrong Content-Type: got %v want %v", contentType, "application/json")
-		}
+	if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("handler returned wrong Content-Type: got %v want %v", contentType, "application/json")
+	}
 
-		var resp SFUResponse
-		err = json.NewDecoder(rr.Body).Decode(&resp)
-		if err != nil {
-			t.Errorf("failed to decode response body %v", err)
-		}
+	var resp SFUResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	if err != nil {
+		t.Errorf("failed to decode response body %v", err)
+	}
 
-		if resp.URL != "wss://lk.local:8080/foo" {
-			t.Errorf("unexpected URL: got %v want %v", resp.URL, "wss://lk.local:8080/foo")
-		}
+	if resp.URL != "wss://lk.local:8080/foo" {
+		t.Errorf("unexpected URL: got %v want %v", resp.URL, "wss://lk.local:8080/foo")
+	}
 
-		if resp.JWT == "" {
-			t.Error("expected JWT to be non-empty")
-		}
+	if resp.JWT == "" {
+		t.Error("expected JWT to be non-empty")
+	}
 
-		// parse JWT checking the shared secret
-		token, err := jwt.Parse(resp.JWT, func(token *jwt.Token) (interface{}, error) {
-			return []byte(handler.secret), nil
-		})
+	// parse JWT checking the shared secret
+	token, err := jwt.Parse(resp.JWT, func(token *jwt.Token) (interface{}, error) {
+		return []byte(handler.secret), nil
+	})
 
-		if err != nil {
-			t.Fatalf("failed to parse JWT: %v", err)
-		}
+	if err != nil {
+		t.Fatalf("failed to parse JWT: %v", err)
+	}
 
-		claims, ok := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
 
-		if !ok || !token.Valid {
-			t.Fatalf("failed to parse claims from JWT: %v", err)
-		}
+	if !ok || !token.Valid {
+		t.Fatalf("failed to parse claims from JWT: %v", err)
+	}
 
-		want_sub_hash := sha256.Sum256([]byte("@user:"+ matrixServerName + "|testDevice|member_test_id"))
-		want_sub := unpaddedBase64.EncodeToString(want_sub_hash[:])
-		if claims["sub"] != want_sub {
-			t.Errorf("unexpected sub: got %v want %v", claims["sub"], "member_test_id")
-		}
+	want_sub_hash := sha256.Sum256([]byte("@user:" + matrixServerName + "|testDevice|member_test_id"))
+	want_sub := unpaddedBase64.EncodeToString(want_sub_hash[:])
+	if claims["sub"] != want_sub {
+		t.Errorf("unexpected sub: got %v want %v", claims["sub"], "member_test_id")
+	}
 
-		// should have permission for the room
-		want_room_hash := sha256.Sum256([]byte("!testRoom:example.com" + "|" +  "m.call#ROOM"))
-		want_room := unpaddedBase64.EncodeToString(want_room_hash[:])
-		if claims["video"].(map[string]interface{})["room"] != want_room {
-			t.Errorf("unexpected room: got %v want %v", claims["video"].(map[string]interface{})["room"], want_room)
-		}
+	// should have permission for the room
+	want_room_hash := sha256.Sum256([]byte("!testRoom:example.com" + "|" + "m.call#ROOM"))
+	want_room := unpaddedBase64.EncodeToString(want_room_hash[:])
+	if claims["video"].(map[string]interface{})["room"] != want_room {
+		t.Errorf("unexpected room: got %v want %v", claims["video"].(map[string]interface{})["room"], want_room)
+	}
 }
 
 func TestLegacyHandlePost(t *testing.T) {
@@ -221,7 +221,7 @@ func TestLegacyHandlePost(t *testing.T) {
 		key:                   "testKey",
 		lkUrl:                 "wss://lk.local:8080/foo",
 		fullAccessHomeservers: []string{"example.com"},
-		skipVerifyTLS:     true,
+		skipVerifyTLS:         true,
 	}
 
 	var matrixServerName = ""
@@ -266,62 +266,62 @@ func TestLegacyHandlePost(t *testing.T) {
 	jsonBody, _ := json.Marshal(testCase)
 
 	req, err := http.NewRequest("POST", "/sfu/get", bytes.NewBuffer(jsonBody))
-		if err != nil {
-			t.Fatal(err)
-		}
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		rr := httptest.NewRecorder()
-		handler.prepareMux().ServeHTTP(rr, req)
+	rr := httptest.NewRecorder()
+	handler.prepareMux().ServeHTTP(rr, req)
 
-		if status := rr.Code; status != http.StatusOK {
-			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
-		}
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
 
-		if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
-			t.Errorf("handler returned wrong Content-Type: got %v want %v", contentType, "application/json")
-		}
+	if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("handler returned wrong Content-Type: got %v want %v", contentType, "application/json")
+	}
 
-		var resp SFUResponse
-		err = json.NewDecoder(rr.Body).Decode(&resp)
-		if err != nil {
-			t.Errorf("failed to decode response body %v", err)
-		}
+	var resp SFUResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	if err != nil {
+		t.Errorf("failed to decode response body %v", err)
+	}
 
-		if resp.URL != "wss://lk.local:8080/foo" {
-			t.Errorf("unexpected URL: got %v want %v", resp.URL, "wss://lk.local:8080/foo")
-		}
+	if resp.URL != "wss://lk.local:8080/foo" {
+		t.Errorf("unexpected URL: got %v want %v", resp.URL, "wss://lk.local:8080/foo")
+	}
 
-		if resp.JWT == "" {
-			t.Error("expected JWT to be non-empty")
-		}
+	if resp.JWT == "" {
+		t.Error("expected JWT to be non-empty")
+	}
 
-		// parse JWT checking the shared secret
-		token, err := jwt.Parse(resp.JWT, func(token *jwt.Token) (interface{}, error) {
-			return []byte(handler.secret), nil
-		})
+	// parse JWT checking the shared secret
+	token, err := jwt.Parse(resp.JWT, func(token *jwt.Token) (interface{}, error) {
+		return []byte(handler.secret), nil
+	})
 
-		if err != nil {
-			t.Fatalf("failed to parse JWT: %v", err)
-		}
+	if err != nil {
+		t.Fatalf("failed to parse JWT: %v", err)
+	}
 
-		claims, ok := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
 
-		if !ok || !token.Valid {
-			t.Fatalf("failed to parse claims from JWT: %v", err)
-		}
+	if !ok || !token.Valid {
+		t.Fatalf("failed to parse claims from JWT: %v", err)
+	}
 
-		if claims["sub"] != "@user:"+matrixServerName+":testDevice" {
-			t.Errorf("unexpected sub: got %v want %v", claims["sub"], "@user:"+matrixServerName+":testDevice")
-		}
+	if claims["sub"] != "@user:"+matrixServerName+":testDevice" {
+		t.Errorf("unexpected sub: got %v want %v", claims["sub"], "@user:"+matrixServerName+":testDevice")
+	}
 
-		slotId := "m.call#ROOM"
-		lkRoomAliasHash := sha256.Sum256([]byte(matrixRoom + "|" + slotId))
-		lkRoomAlias := unpaddedBase64.EncodeToString(lkRoomAliasHash[:])
+	slotId := "m.call#ROOM"
+	lkRoomAliasHash := sha256.Sum256([]byte(matrixRoom + "|" + slotId))
+	lkRoomAlias := unpaddedBase64.EncodeToString(lkRoomAliasHash[:])
 
-		// should have permission for the room
-		if claims["video"].(map[string]interface{})["room"] != lkRoomAlias {
-			t.Errorf("unexpected room: got %v want %v", claims["room"], lkRoomAlias)
-		}
+	// should have permission for the room
+	if claims["video"].(map[string]interface{})["room"] != lkRoomAlias {
+		t.Errorf("unexpected room: got %v want %v", claims["room"], lkRoomAlias)
+	}
 }
 
 func TestIsFullAccessUser(t *testing.T) {
@@ -330,7 +330,7 @@ func TestIsFullAccessUser(t *testing.T) {
 		key:                   "testKey",
 		lkUrl:                 "wss://lk.local:8080/foo",
 		fullAccessHomeservers: []string{"example.com", "another.example.com"},
-		skipVerifyTLS:     true,
+		skipVerifyTLS:         true,
 	}
 
 	// Test cases for full access users
@@ -340,20 +340,20 @@ func TestIsFullAccessUser(t *testing.T) {
 		t.Error("User has restricted access")
 	}
 
-    if handler.isFullAccessUser("another.example.com") {
+	if handler.isFullAccessUser("another.example.com") {
 		t.Log("User has full access")
 	} else {
 		t.Error("User has restricted access")
 	}
 
 	// Test cases for restricted access users
-    if handler.isFullAccessUser("aanother.example.com") {
+	if handler.isFullAccessUser("aanother.example.com") {
 		t.Error("User has full access")
 	} else {
 		t.Log("User has restricted access")
 	}
 
-    if handler.isFullAccessUser("matrix.example.com") {
+	if handler.isFullAccessUser("matrix.example.com") {
 		t.Error("User has full access")
 	} else {
 		t.Log("User has restricted access")
@@ -361,7 +361,7 @@ func TestIsFullAccessUser(t *testing.T) {
 
 	// test wildcard access
 	handler.fullAccessHomeservers = []string{"*"}
-    if handler.isFullAccessUser("other.com") {
+	if handler.isFullAccessUser("other.com") {
 		t.Log("User has full access")
 	} else {
 		t.Error("User has restricted access")
@@ -373,31 +373,31 @@ func TestGetJoinToken(t *testing.T) {
 	apiSecret := "testSecret"
 	room := "testRoom"
 	identity := "testIdentity@example.com"
-	
+
 	tokenString, err := getJoinToken(apiKey, apiSecret, room, identity)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	
+
 	if tokenString == "" {
 		t.Error("expected token to be non-empty")
 	}
-	
+
 	// parse JWT checking the shared secret
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte(apiSecret), nil
 	})
 	claims, ok := token.Claims.(jwt.MapClaims)
-	
+
 	if !ok || !token.Valid {
 		t.Fatalf("failed to parse claims from JWT: %v", err)
 	}
-	
+
 	claimRoomCreate := claims["video"].(map[string]interface{})["roomCreate"]
 	if claimRoomCreate == nil {
 		claimRoomCreate = false
 	}
-	
+
 	if claimRoomCreate == true {
 		t.Fatalf("roomCreate property needs to be false, since the lk-jwt-service creates the room")
 	}
@@ -490,172 +490,197 @@ func TestReadKeySecret(t *testing.T) {
 }
 
 func TestParseConfig(t *testing.T) {
-    testCases := []struct {
-        name        string
-        env         map[string]string
-        wantConfig  *Config
-        wantErrMsg  string
-    }{
-        {
-            name: "Minimal valid config",
-            env: map[string]string{
-                "LIVEKIT_KEY":    "test_key",
-                "LIVEKIT_SECRET": "test_secret",
-                "LIVEKIT_URL":    "wss://test.livekit.cloud",
-            },
-            wantConfig: &Config{
-                Key:                   "test_key",
-                Secret:                "test_secret",
-                LkUrl:                 "wss://test.livekit.cloud",
-                SkipVerifyTLS:         false,
-                FullAccessHomeservers: []string{"*"},
-                LkJwtBind:               ":8080",
-            },
-        },
-        {
-            name: "Full config with all options",
-            env: map[string]string{
-                "LIVEKIT_KEY":                      "test_key",
-                "LIVEKIT_SECRET":                   "test_secret",
-                "LIVEKIT_URL":                      "wss://test.livekit.cloud",
-                "LIVEKIT_FULL_ACCESS_HOMESERVERS":  "example.com, test.com",
-                "LIVEKIT_JWT_BIND":                 ":9090",
-                "LIVEKIT_INSECURE_SKIP_VERIFY_TLS": "YES_I_KNOW_WHAT_I_AM_DOING",
-            },
-            wantConfig: &Config{
-                Key:                   "test_key",
-                Secret:                "test_secret",
-                LkUrl:                 "wss://test.livekit.cloud",
-                SkipVerifyTLS:         true,
-                FullAccessHomeservers: []string{"example.com", "test.com"},
-                LkJwtBind:               ":9090",
-            },
-        },
-        {
-            name: "Legacy port configuration",
-            env: map[string]string{
-                "LIVEKIT_KEY":      "test_key",
-                "LIVEKIT_SECRET":   "test_secret",
-                "LIVEKIT_URL":      "wss://test.livekit.cloud",
-                "LIVEKIT_JWT_PORT": "9090",
-            },
-            wantConfig: &Config{
-                Key:                   "test_key",
-                Secret:                "test_secret",
-                LkUrl:                 "wss://test.livekit.cloud",
-                SkipVerifyTLS:         false,
-                FullAccessHomeservers: []string{"*"},
-                LkJwtBind:             ":9090",
-            },
-        },
-        {
-            name: "Legacy full-access homeservers configuration",
-            env: map[string]string{
-                "LIVEKIT_KEY":               "test_key",
-                "LIVEKIT_SECRET":            "test_secret",
-                "LIVEKIT_URL":               "wss://test.livekit.cloud",
-                "LIVEKIT_LOCAL_HOMESERVERS": "legacy.com",
-            },
-            wantConfig: &Config{
-                Key:                   "test_key",
-                Secret:                "test_secret",
-                LkUrl:                 "wss://test.livekit.cloud",
-                SkipVerifyTLS:         false,
-                FullAccessHomeservers: []string{"legacy.com"},
-                LkJwtBind:               ":8080",
-            },
-        },
-        {
-            name: "Missing required config",
-            env: map[string]string{
-                "LIVEKIT_KEY": "test_key",
-            },
-            wantErrMsg: "LIVEKIT_KEY[_FILE], LIVEKIT_SECRET[_FILE] and LIVEKIT_URL environment variables must be set",
-        },
-        {
-            name: "Conflicting bind configuration",
-            env: map[string]string{
-                "LIVEKIT_KEY":    "test_key",
-                "LIVEKIT_SECRET": "test_secret",
-                "LIVEKIT_URL":    "wss://test.livekit.cloud",
-                "LIVEKIT_JWT_BIND": ":9090",
-                "LIVEKIT_JWT_PORT": "8080",
-            },
-            wantErrMsg: "LIVEKIT_JWT_BIND and LIVEKIT_JWT_PORT environment variables MUST NOT be set together",
-        },
-    }
+	testCases := []struct {
+		name       string
+		env        map[string]string
+		wantConfig *Config
+		wantErrMsg string
+	}{
+		{
+			name: "Minimal valid config",
+			env: map[string]string{
+				"LIVEKIT_KEY":    "test_key",
+				"LIVEKIT_SECRET": "test_secret",
+				"LIVEKIT_URL":    "wss://test.livekit.cloud",
+			},
+			wantConfig: &Config{
+				Key:                   "test_key",
+				Secret:                "test_secret",
+				LkUrl:                 "wss://test.livekit.cloud",
+				SkipVerifyTLS:         false,
+				FullAccessHomeservers: []string{"*"},
+				LkJwtBind:             ":8080",
+				LkJwtNetworkType:      "tcp",
+			},
+		},
+		{
+			name: "Full config with all options",
+			env: map[string]string{
+				"LIVEKIT_KEY":                      "test_key",
+				"LIVEKIT_SECRET":                   "test_secret",
+				"LIVEKIT_URL":                      "wss://test.livekit.cloud",
+				"LIVEKIT_FULL_ACCESS_HOMESERVERS":  "example.com, test.com",
+				"LIVEKIT_JWT_BIND":                 ":9090",
+				"LIVEKIT_INSECURE_SKIP_VERIFY_TLS": "YES_I_KNOW_WHAT_I_AM_DOING",
+			},
+			wantConfig: &Config{
+				Key:                   "test_key",
+				Secret:                "test_secret",
+				LkUrl:                 "wss://test.livekit.cloud",
+				SkipVerifyTLS:         true,
+				FullAccessHomeservers: []string{"example.com", "test.com"},
+				LkJwtBind:             ":9090",
+				LkJwtNetworkType:      "tcp",
+			},
+		},
+		{
+			name: "Legacy port configuration",
+			env: map[string]string{
+				"LIVEKIT_KEY":      "test_key",
+				"LIVEKIT_SECRET":   "test_secret",
+				"LIVEKIT_URL":      "wss://test.livekit.cloud",
+				"LIVEKIT_JWT_PORT": "9090",
+			},
+			wantConfig: &Config{
+				Key:                   "test_key",
+				Secret:                "test_secret",
+				LkUrl:                 "wss://test.livekit.cloud",
+				SkipVerifyTLS:         false,
+				FullAccessHomeservers: []string{"*"},
+				LkJwtBind:             ":9090",
+				LkJwtNetworkType:      "tcp",
+			},
+		},
+		{
+			name: "Legacy full-access homeservers configuration",
+			env: map[string]string{
+				"LIVEKIT_KEY":               "test_key",
+				"LIVEKIT_SECRET":            "test_secret",
+				"LIVEKIT_URL":               "wss://test.livekit.cloud",
+				"LIVEKIT_LOCAL_HOMESERVERS": "legacy.com",
+			},
+			wantConfig: &Config{
+				Key:                   "test_key",
+				Secret:                "test_secret",
+				LkUrl:                 "wss://test.livekit.cloud",
+				SkipVerifyTLS:         false,
+				FullAccessHomeservers: []string{"legacy.com"},
+				LkJwtBind:             ":8080",
+				LkJwtNetworkType:      "tcp",
+			},
+		},
+		{
+			name: "Missing required config",
+			env: map[string]string{
+				"LIVEKIT_KEY": "test_key",
+			},
+			wantErrMsg: "LIVEKIT_KEY[_FILE], LIVEKIT_SECRET[_FILE] and LIVEKIT_URL environment variables must be set",
+		},
+		{
+			name: "Conflicting bind configuration",
+			env: map[string]string{
+				"LIVEKIT_KEY":      "test_key",
+				"LIVEKIT_SECRET":   "test_secret",
+				"LIVEKIT_URL":      "wss://test.livekit.cloud",
+				"LIVEKIT_JWT_BIND": ":9090",
+				"LIVEKIT_JWT_PORT": "8080",
+			},
+			wantErrMsg: "LIVEKIT_JWT_BIND and LIVEKIT_JWT_PORT environment variables MUST NOT be set together",
+		},
+		{
+			name: "Assert that the default `LkJwtNetworkType` is applied",
+			env: map[string]string{
+				"LIVEKIT_KEY":              "test_key",
+				"LIVEKIT_SECRET":           "test_secret",
+				"LIVEKIT_URL":              "wss://test.livekit.cloud",
+				"LIVEKIT_JWT_NETWORK_TYPE": "test",
+			},
+			wantConfig: &Config{
+				Key:                   "test_key",
+				Secret:                "test_secret",
+				LkUrl:                 "wss://test.livekit.cloud",
+				SkipVerifyTLS:         false,
+				FullAccessHomeservers: []string{"*"},
+				LkJwtBind:             ":8080",
+				LkJwtNetworkType:      "test",
+			},
+		},
+	}
 
-    for _, tc := range testCases {
-        t.Run(tc.name, func(t *testing.T) {
-            // Setup: set env variables
-            for k, v := range tc.env {
-                if err := os.Setenv(k, v); err != nil {
-                    t.Fatalf("Failed to set environment variable %s: %v", k, err)
-                }
-            }
-            defer func() {
-                // Cleanup: reset env variables after test
-                for k := range tc.env {
-                    if err := os.Unsetenv(k); err != nil {
-                        t.Errorf("Failed to unset environment variable %s: %v", k, err)
-                    }
-                }
-            }()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup: set env variables
+			for k, v := range tc.env {
+				if err := os.Setenv(k, v); err != nil {
+					t.Fatalf("Failed to set environment variable %s: %v", k, err)
+				}
+			}
+			defer func() {
+				// Cleanup: reset env variables after test
+				for k := range tc.env {
+					if err := os.Unsetenv(k); err != nil {
+						t.Errorf("Failed to unset environment variable %s: %v", k, err)
+					}
+				}
+			}()
 
-            // parse config from env variables
-            got, err := parseConfig()
+			// parse config from env variables
+			got, err := parseConfig()
 
-            // Given error(s), check potential error messages
-            if tc.wantErrMsg != "" {
-                if err == nil {
-                    t.Errorf("parseConfig() error = nil, wantErr %q", tc.wantErrMsg)
-                    return
-                }
-                if err.Error() != tc.wantErrMsg {
-                    t.Errorf("parseConfig() error = %q, wantErr %q", err.Error(), tc.wantErrMsg)
-                }
-                return
-            }
+			// Given error(s), check potential error messages
+			if tc.wantErrMsg != "" {
+				if err == nil {
+					t.Errorf("parseConfig() error = nil, wantErr %q", tc.wantErrMsg)
+					return
+				}
+				if err.Error() != tc.wantErrMsg {
+					t.Errorf("parseConfig() error = %q, wantErr %q", err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
 
-            // Given no error, check for unexpected error messages
-            if err != nil {
-                t.Errorf("parseConfig() unexpected error: %v", err)
-                return
-            }
+			// Given no error, check for unexpected error messages
+			if err != nil {
+				t.Errorf("parseConfig() unexpected error: %v", err)
+				return
+			}
 
-            // Compare parsed (got) config with wanted config
-            if got.Key != tc.wantConfig.Key {
-                t.Errorf("Key = %q, want %q", got.Key, tc.wantConfig.Key)
-            }
-            if got.Secret != tc.wantConfig.Secret {
-                t.Errorf("Secret = %q, want %q", got.Secret, tc.wantConfig.Secret)
-            }
-            if got.LkUrl != tc.wantConfig.LkUrl {
-                t.Errorf("LkUrl = %q, want %q", got.LkUrl, tc.wantConfig.LkUrl)
-            }
-            if got.SkipVerifyTLS != tc.wantConfig.SkipVerifyTLS {
-                t.Errorf("SkipVerifyTLS = %v, want %v", got.SkipVerifyTLS, tc.wantConfig.SkipVerifyTLS)
-            }
-            if !reflect.DeepEqual(got.FullAccessHomeservers, tc.wantConfig.FullAccessHomeservers) {
-                t.Errorf("FullAccessHomeservers = %v, want %v", got.FullAccessHomeservers, tc.wantConfig.FullAccessHomeservers)
-            }
-            if got.LkJwtBind != tc.wantConfig.LkJwtBind {
-                t.Errorf("JwtBind = %q, want %q", got.LkJwtBind, tc.wantConfig.LkJwtBind)
-            }
-        })
-    }
+			// Compare parsed (got) config with wanted config
+			if got.Key != tc.wantConfig.Key {
+				t.Errorf("Key = %q, want %q", got.Key, tc.wantConfig.Key)
+			}
+			if got.Secret != tc.wantConfig.Secret {
+				t.Errorf("Secret = %q, want %q", got.Secret, tc.wantConfig.Secret)
+			}
+			if got.LkUrl != tc.wantConfig.LkUrl {
+				t.Errorf("LkUrl = %q, want %q", got.LkUrl, tc.wantConfig.LkUrl)
+			}
+			if got.SkipVerifyTLS != tc.wantConfig.SkipVerifyTLS {
+				t.Errorf("SkipVerifyTLS = %v, want %v", got.SkipVerifyTLS, tc.wantConfig.SkipVerifyTLS)
+			}
+			if !reflect.DeepEqual(got.FullAccessHomeservers, tc.wantConfig.FullAccessHomeservers) {
+				t.Errorf("FullAccessHomeservers = %v, want %v", got.FullAccessHomeservers, tc.wantConfig.FullAccessHomeservers)
+			}
+			if got.LkJwtBind != tc.wantConfig.LkJwtBind {
+				t.Errorf("JwtBind = %q, want %q", got.LkJwtBind, tc.wantConfig.LkJwtBind)
+			}
+			if got.LkJwtNetworkType != tc.wantConfig.LkJwtNetworkType {
+				t.Errorf("JwtNetworkType = %q, want %q", got.LkJwtNetworkType, tc.wantConfig.LkJwtNetworkType)
+			}
+		})
+	}
 }
 
 func TestMapSFURequest(t *testing.T) {
-    testCases := []struct {
-        name        string
-        input       string
-        want        any
-        wantErrCode string
-    }{
-        {
-            name: "Valid legacy request",
-            input: `{
+	testCases := []struct {
+		name        string
+		input       string
+		want        any
+		wantErrCode string
+	}{
+		{
+			name: "Valid legacy request",
+			input: `{
                 "room": "testRoom",
                 "openid_token": {
                     "access_token": "test_token",
@@ -665,20 +690,20 @@ func TestMapSFURequest(t *testing.T) {
                 },
                 "device_id": "testDevice"
             }`,
-            want: &LegacySFURequest{
-                Room: "testRoom",
-                OpenIDToken: OpenIDTokenType{
-                    AccessToken:      "test_token",
-                    TokenType:        "Bearer",
-                    MatrixServerName: "example.com",
-                    ExpiresIn:        3600,
-                },
-                DeviceID: "testDevice",
-            },
-        },
-        {
-            name: "Valid Matrix2 request",
-            input: `{
+			want: &LegacySFURequest{
+				Room: "testRoom",
+				OpenIDToken: OpenIDTokenType{
+					AccessToken:      "test_token",
+					TokenType:        "Bearer",
+					MatrixServerName: "example.com",
+					ExpiresIn:        3600,
+				},
+				DeviceID: "testDevice",
+			},
+		},
+		{
+			name: "Valid Matrix2 request",
+			input: `{
                 "room_id": "!testRoom:example.com",
                 "slot_id": "123",
                 "openid_token": {
@@ -693,37 +718,37 @@ func TestMapSFURequest(t *testing.T) {
                     "claimed_device_id": "testDevice"
                 }
             }`,
-            want: &SFURequest{
-                RoomID: "!testRoom:example.com",
-                SlotID: "123",
-                OpenIDToken: OpenIDTokenType{
-                    AccessToken:      "test_token",
-                    TokenType:        "Bearer",
-                    MatrixServerName: "example.com",
-                    ExpiresIn:        3600,
-                },
-                Member: MatrixRTCMemberType{
-                    ID:              "test_id",
-                    ClaimedUserID:   "@test:example.com",
-                    ClaimedDeviceID: "testDevice",
-                },
-            },
-        },
-        {
-            name:        "Invalid JSON",
-            input:       `{"invalid": json}`,
-            want:        nil,
-            wantErrCode: "M_BAD_JSON",
-        },
-        {
-            name:        "Empty request",
-            input:       `{}`,
-            want:        nil,
+			want: &SFURequest{
+				RoomID: "!testRoom:example.com",
+				SlotID: "123",
+				OpenIDToken: OpenIDTokenType{
+					AccessToken:      "test_token",
+					TokenType:        "Bearer",
+					MatrixServerName: "example.com",
+					ExpiresIn:        3600,
+				},
+				Member: MatrixRTCMemberType{
+					ID:              "test_id",
+					ClaimedUserID:   "@test:example.com",
+					ClaimedDeviceID: "testDevice",
+				},
+			},
+		},
+		{
+			name:        "Invalid JSON",
+			input:       `{"invalid": json}`,
+			want:        nil,
 			wantErrCode: "M_BAD_JSON",
-        },
-        {
-            name: "Invalid legacy request with extra field",
-            input: `{
+		},
+		{
+			name:        "Empty request",
+			input:       `{}`,
+			want:        nil,
+			wantErrCode: "M_BAD_JSON",
+		},
+		{
+			name: "Invalid legacy request with extra field",
+			input: `{
                 "room": "testRoom",
                 "openid_token": {
                     "access_token": "test_token",
@@ -734,61 +759,61 @@ func TestMapSFURequest(t *testing.T) {
                 "device_id": "testDevice",
                 "extra_field": "should_fail"
             }`,
-            want:        nil,
-            wantErrCode: "M_BAD_JSON",
-        },
-    }
+			want:        nil,
+			wantErrCode: "M_BAD_JSON",
+		},
+	}
 
-    for _, tc := range testCases {
-        t.Run(tc.name, func(t *testing.T) {
-            // Convert string to []byte for input
-            input := []byte(tc.input)
-            
-            // Call mapSFURequest
-            got, err := mapSFURequest(&input)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert string to []byte for input
+			input := []byte(tc.input)
 
-            // Check error cases
-            if tc.wantErrCode != "" {
-                matrixErr := &MatrixErrorResponse{}
-                if !errors.As(err, &matrixErr) {
-                    t.Errorf("mapSFURequest() error = %v, want MatrixErrorResponse", err)
-                    return
-                }
-                if matrixErr.ErrCode != tc.wantErrCode {
-                    t.Errorf("mapSFURequest() error code = %v, want %v", matrixErr.ErrCode, tc.wantErrCode)
-                }
-                return
-            }
+			// Call mapSFURequest
+			got, err := mapSFURequest(&input)
 
-            // Check success cases
-            if err != nil {
-                t.Errorf("mapSFURequest() unexpected error: %v", err)
-                return
-            }
+			// Check error cases
+			if tc.wantErrCode != "" {
+				matrixErr := &MatrixErrorResponse{}
+				if !errors.As(err, &matrixErr) {
+					t.Errorf("mapSFURequest() error = %v, want MatrixErrorResponse", err)
+					return
+				}
+				if matrixErr.ErrCode != tc.wantErrCode {
+					t.Errorf("mapSFURequest() error code = %v, want %v", matrixErr.ErrCode, tc.wantErrCode)
+				}
+				return
+			}
 
-            // Type-specific comparisons
-            switch expected := tc.want.(type) {
-            case *LegacySFURequest:
-                actual, ok := got.(*LegacySFURequest)
-                if !ok {
-                    t.Errorf("mapSFURequest() returned wrong type, got %T, want *LegacySFURequest", got)
-                    return
-                }
-                if !reflect.DeepEqual(actual, expected) {
-                    t.Errorf("mapSFURequest() = %+v, want %+v", actual, expected)
-                }
-            case *SFURequest:
-                actual, ok := got.(*SFURequest)
-                if !ok {
-                    t.Errorf("mapSFURequest() returned wrong type, got %T, want *SFURequest", got)
-                    return
-                }
-                if !reflect.DeepEqual(actual, expected) {
-                    t.Errorf("mapSFURequest() = %+v, want %+v", actual, expected)
-                }
-            }
-        })
-    }
+			// Check success cases
+			if err != nil {
+				t.Errorf("mapSFURequest() unexpected error: %v", err)
+				return
+			}
+
+			// Type-specific comparisons
+			switch expected := tc.want.(type) {
+			case *LegacySFURequest:
+				actual, ok := got.(*LegacySFURequest)
+				if !ok {
+					t.Errorf("mapSFURequest() returned wrong type, got %T, want *LegacySFURequest", got)
+					return
+				}
+				if !reflect.DeepEqual(actual, expected) {
+					t.Errorf("mapSFURequest() = %+v, want %+v", actual, expected)
+				}
+			case *SFURequest:
+				actual, ok := got.(*SFURequest)
+				if !ok {
+					t.Errorf("mapSFURequest() returned wrong type, got %T, want *SFURequest", got)
+					return
+				}
+				if !reflect.DeepEqual(actual, expected) {
+					t.Errorf("mapSFURequest() = %+v, want %+v", actual, expected)
+				}
+			}
+		})
+	}
 }
 
 func TestMapSFURequestMemoryLeak(t *testing.T) {
@@ -842,33 +867,33 @@ func TestMapSFURequestMemoryLeak(t *testing.T) {
 }
 
 func TestProcessSFURequest(t *testing.T) {
-    // mock createLiveKitRoom
-    var called_createLiveKitRoom bool
+	// mock createLiveKitRoom
+	var called_createLiveKitRoom bool
 	original_createLiveKitRoom := createLiveKitRoom
-    createLiveKitRoom = func(ctx context.Context, h *Handler, room, matrixUser, lkIdentity string) error {
-        called_createLiveKitRoom = true
-        if room == "" {
-            t.Error("expected room name passed into mock")
-        }
-        return nil
-    }
-    t.Cleanup(func() { createLiveKitRoom = original_createLiveKitRoom })
+	createLiveKitRoom = func(ctx context.Context, h *Handler, room, matrixUser, lkIdentity string) error {
+		called_createLiveKitRoom = true
+		if room == "" {
+			t.Error("expected room name passed into mock")
+		}
+		return nil
+	}
+	t.Cleanup(func() { createLiveKitRoom = original_createLiveKitRoom })
 
-    // mock OpenID lookup
+	// mock OpenID lookup
 	var failed_exchangeOpenIdUserInfo bool
 	var exchangeOpenIdUserInfo_MatrixID string
-    original_exchangeOpenIdUserInfo := exchangeOpenIdUserInfo
-    exchangeOpenIdUserInfo = func(ctx context.Context, token OpenIDTokenType, skip bool) (*fclient.UserInfo, error) {
-        if failed_exchangeOpenIdUserInfo {
+	original_exchangeOpenIdUserInfo := exchangeOpenIdUserInfo
+	exchangeOpenIdUserInfo = func(ctx context.Context, token OpenIDTokenType, skip bool) (*fclient.UserInfo, error) {
+		if failed_exchangeOpenIdUserInfo {
 			return nil, &MatrixErrorResponse{
-				Status: http.StatusUnauthorized,
+				Status:  http.StatusUnauthorized,
 				ErrCode: "M_UNAUTHORIZED",
-				Err: "The request could not be authorised.",
+				Err:     "The request could not be authorised.",
 			}
-        }	
-        return &fclient.UserInfo{Sub: exchangeOpenIdUserInfo_MatrixID}, nil
-    }
-    t.Cleanup(func() { exchangeOpenIdUserInfo = original_exchangeOpenIdUserInfo })
+		}
+		return &fclient.UserInfo{Sub: exchangeOpenIdUserInfo_MatrixID}, nil
+	}
+	t.Cleanup(func() { exchangeOpenIdUserInfo = original_exchangeOpenIdUserInfo })
 
 	type testCase struct {
 		name                       string
@@ -884,18 +909,18 @@ func TestProcessSFURequest(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:                       "Full access user + all OK",
-			MatrixID:                   "@user:example.com",
-			ClaimedMatrixID:            "@user:example.com",
-			expectCreateRoomCall:       true,
-			expectError:                false,
+			name:                 "Full access user + all OK",
+			MatrixID:             "@user:example.com",
+			ClaimedMatrixID:      "@user:example.com",
+			expectCreateRoomCall: true,
+			expectError:          false,
 		},
 		{
-			name:                       "Restricted user + all OK",
-			MatrixID:                   "@user:otherdomain.com",
-			ClaimedMatrixID:            "@user:otherdomain.com",
-			expectCreateRoomCall:       false,
-			expectError:                false,
+			name:                 "Restricted user + all OK",
+			MatrixID:             "@user:otherdomain.com",
+			ClaimedMatrixID:      "@user:otherdomain.com",
+			expectCreateRoomCall: false,
+			expectError:          false,
 		},
 		{
 			name:                       "Full access user but exchangeOpenIdUserInfo fails",
@@ -907,22 +932,22 @@ func TestProcessSFURequest(t *testing.T) {
 			expectError:                true,
 		},
 		{
-			name:                       "Full access user but getJoinToken fails",
-			MatrixID:                   "@user:example.com",
-			ClaimedMatrixID:            "@user:example.com",
-			expectJoinTokenError:       true,
-			getJoinTokenErr:            &MatrixErrorResponse{},
-			expectCreateRoomCall:       false,
-			expectError:                true,
+			name:                 "Full access user but getJoinToken fails",
+			MatrixID:             "@user:example.com",
+			ClaimedMatrixID:      "@user:example.com",
+			expectJoinTokenError: true,
+			getJoinTokenErr:      &MatrixErrorResponse{},
+			expectCreateRoomCall: false,
+			expectError:          true,
 		},
 		{
-			name:                       "Full access user but claimed_matrix_id fails",
-			MatrixID:                   "@user:example.com",
-			ClaimedMatrixID:            "@user:faked.com",
-			expectJoinTokenError:       false,
-			getJoinTokenErr:            &MatrixErrorResponse{},
-			expectCreateRoomCall:       false,
-			expectError:                true,
+			name:                 "Full access user but claimed_matrix_id fails",
+			MatrixID:             "@user:example.com",
+			ClaimedMatrixID:      "@user:faked.com",
+			expectJoinTokenError: false,
+			getJoinTokenErr:      &MatrixErrorResponse{},
+			expectCreateRoomCall: false,
+			expectError:          true,
 		},
 	}
 
@@ -933,7 +958,7 @@ func TestProcessSFURequest(t *testing.T) {
 			failed_exchangeOpenIdUserInfo = tc.expectExchangeOpendIdError
 			exchangeOpenIdUserInfo_MatrixID = tc.MatrixID
 
-		    handler := &Handler{
+			handler := &Handler{
 				key:                   map[bool]string{true: "", false: "the_api_key"}[tc.expectJoinTokenError],
 				secret:                "secret",
 				lkUrl:                 "wss://lk.local:8080/foo",
@@ -969,36 +994,35 @@ func TestProcessSFURequest(t *testing.T) {
 		})
 	}
 
-
 }
 
 func TestProcessLegacySFURequest(t *testing.T) {
-    // mock createLiveKitRoom
-    var called_createLiveKitRoom bool
+	// mock createLiveKitRoom
+	var called_createLiveKitRoom bool
 	original_createLiveKitRoom := createLiveKitRoom
-    createLiveKitRoom = func(ctx context.Context, h *Handler, room, matrixUser, lkIdentity string) error {
-        called_createLiveKitRoom = true
-        if room == "" {
-            t.Error("expected room name passed into mock")
-        }
-        return nil
-    }
-    t.Cleanup(func() { createLiveKitRoom = original_createLiveKitRoom })
+	createLiveKitRoom = func(ctx context.Context, h *Handler, room, matrixUser, lkIdentity string) error {
+		called_createLiveKitRoom = true
+		if room == "" {
+			t.Error("expected room name passed into mock")
+		}
+		return nil
+	}
+	t.Cleanup(func() { createLiveKitRoom = original_createLiveKitRoom })
 
-    // mock OpenID lookup
+	// mock OpenID lookup
 	var failed_exchangeOpenIdUserInfo bool
-    original_exchangeOpenIdUserInfo := exchangeOpenIdUserInfo
-    exchangeOpenIdUserInfo = func(ctx context.Context, token OpenIDTokenType, skip bool) (*fclient.UserInfo, error) {
-        if failed_exchangeOpenIdUserInfo {
+	original_exchangeOpenIdUserInfo := exchangeOpenIdUserInfo
+	exchangeOpenIdUserInfo = func(ctx context.Context, token OpenIDTokenType, skip bool) (*fclient.UserInfo, error) {
+		if failed_exchangeOpenIdUserInfo {
 			return nil, &MatrixErrorResponse{
-				Status: http.StatusUnauthorized,
+				Status:  http.StatusUnauthorized,
 				ErrCode: "M_UNAUTHORIZED",
-				Err: "The request could not be authorised.",
+				Err:     "The request could not be authorised.",
 			}
-        }	
-        return &fclient.UserInfo{Sub: "@mock:example.com"}, nil
-    }
-    t.Cleanup(func() { exchangeOpenIdUserInfo = original_exchangeOpenIdUserInfo })
+		}
+		return &fclient.UserInfo{Sub: "@mock:example.com"}, nil
+	}
+	t.Cleanup(func() { exchangeOpenIdUserInfo = original_exchangeOpenIdUserInfo })
 
 	type testCase struct {
 		name                       string
@@ -1013,16 +1037,16 @@ func TestProcessLegacySFURequest(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:                       "Full access user + all OK",
-			MatrixID:                   "@user:example.com",
-			expectCreateRoomCall:       true,
-			expectError:                false,
+			name:                 "Full access user + all OK",
+			MatrixID:             "@user:example.com",
+			expectCreateRoomCall: true,
+			expectError:          false,
 		},
 		{
-			name:                       "Restricted user + all OK",
-			MatrixID:                   "@user:otherdomain.com",
-			expectCreateRoomCall:       false,
-			expectError:                false,
+			name:                 "Restricted user + all OK",
+			MatrixID:             "@user:otherdomain.com",
+			expectCreateRoomCall: false,
+			expectError:          false,
 		},
 		{
 			name:                       "Full access user but exchangeOpenIdUserInfo fails",
@@ -1033,12 +1057,12 @@ func TestProcessLegacySFURequest(t *testing.T) {
 			expectError:                true,
 		},
 		{
-			name:                       "Full access user but getJoinToken fails",
-			MatrixID:                   "@user:example.com",
-			expectJoinTokenError:       true,
-			getJoinTokenErr:            &MatrixErrorResponse{},
-			expectCreateRoomCall:       false,
-			expectError:                true,
+			name:                 "Full access user but getJoinToken fails",
+			MatrixID:             "@user:example.com",
+			expectJoinTokenError: true,
+			getJoinTokenErr:      &MatrixErrorResponse{},
+			expectCreateRoomCall: false,
+			expectError:          true,
 		},
 	}
 
@@ -1048,7 +1072,7 @@ func TestProcessLegacySFURequest(t *testing.T) {
 			called_createLiveKitRoom = false
 			failed_exchangeOpenIdUserInfo = tc.expectExchangeOpendIdError
 
-		    handler := &Handler{
+			handler := &Handler{
 				key:                   map[bool]string{true: "", false: "the_api_key"}[tc.expectJoinTokenError],
 				secret:                "secret",
 				lkUrl:                 "wss://lk.local:8080/foo",
@@ -1078,6 +1102,5 @@ func TestProcessLegacySFURequest(t *testing.T) {
 
 		})
 	}
-
 
 }


### PR DESCRIPTION
This could be used to enable the use of Unix Sockets [1] when using a reverse-proxy.

There are also a great deal of `go fmt` changes related to the usage of spaces instead of tabs for indentation (afaik. The standard way of doing indentation in go is using tabs).

This fixes #155 and is the sequel to #118

Sorry for coming up with this late, I was kind of busy with personal stuff

1: https://en.wikipedia.org/wiki/Unix_domain_socket