### PR TITLE
Update Docker image version in installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Releases are available
 ### 🐳 From Docker Image
 
 ```shell
-docker run -e LIVEKIT_URL="ws://somewhere" -e LIVEKIT_KEY=devkey -e LIVEKIT_SECRET=secret -e LIVEKIT_FULL_ACCESS_HOMESERVERS=example.com -p 8080:8080 ghcr.io/element-hq/lk-jwt-service:0.3.0
+docker run -e LIVEKIT_URL="ws://somewhere" -e LIVEKIT_KEY=devkey -e LIVEKIT_SECRET=secret -e LIVEKIT_FULL_ACCESS_HOMESERVERS=example.com -p 8080:8080 ghcr.io/element-hq/lk-jwt-service:latest
 ```
 
 ### 📦 From Release


### PR DESCRIPTION
The Docker image version used in the installation instructions in the README is old enough that it may not work with modern clients.

As the manual instructions use the latest release, I have mirrored this for Docker, and switched the command to use the `latest` tag.