### PR TITLE
Adapted the lastest JSON signature from MSC4195 for SFURequest

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,9 @@ type SFURequest struct {
 	SlotID         string              `json:"slot_id"`
 	OpenIDToken    OpenIDTokenType     `json:"openid_token"`
 	Member         MatrixRTCMemberType `json:"member"`
+    // Note, proper parsing and handling of the additional information needed for the 
+	// delegation of the MatrixRTC member leave event is part of
+	// PR#171. For now we "only" provide the JSON signature.	
 	DelayId        string              `json:"delay_id,omitempty"`
 	DelayTimeout   int                 `json:"delay_timeout,omitempty"`
 	DelayCsApiUrl  string              `json:"delay_cs_api_url,omitempty"`}

--- a/main.go
+++ b/main.go
@@ -69,8 +69,9 @@ type SFURequest struct {
 	SlotID         string              `json:"slot_id"`
 	OpenIDToken    OpenIDTokenType     `json:"openid_token"`
 	Member         MatrixRTCMemberType `json:"member"`
-	DelayedEventID string              `json:"delayed_event_id"`
-}
+	DelayId        string              `json:"delay_id,omitempty"`
+	DelayTimeout   int                 `json:"delay_timeout,omitempty"`
+	DelayCsApiUrl  string              `json:"delay_cs_api_url,omitempty"`}
 type SFUResponse struct {
 	URL string `json:"url"`
 	JWT string `json:"jwt"`


### PR DESCRIPTION
This PR does match the required JSON fields from https://github.com/hughns/matrix-spec-proposals/blob/hughns/matrixrtc-livekit/proposals/4195-matrixrtc-livekit.md#request

Note, proper parsing and handling of the additional information needed for the delegation of the MatrixRTC member leave event is part of #171. This PR intents "only" to fix the JSON signature. 