### PR TITLE
Log the errors that cause "Unable to create room on SFU"

### DIFF
--- a/main.go
+++ b/main.go
@@ -261,6 +261,7 @@ func (h *Handler) processLegacySFURequest(r *http.Request, req *LegacySFURequest
 
     if isFullAccessUser {
         if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
+			log.Printf("Error creating LiveKit room: %v", err)
 			return nil, &MatrixErrorResponse{
 				Status: http.StatusInternalServerError,
 				ErrCode: "M_UNKNOWN",
@@ -331,6 +332,7 @@ func (h *Handler) processSFURequest(r *http.Request, req *SFURequest) (*SFURespo
 
     if isFullAccessUser {
         if err := createLiveKitRoom(r.Context(), h, lkRoomAlias, userInfo.Sub, lkIdentity); err != nil {
+			log.Printf("Error creating LiveKit room: %v", err)
 			return nil, &MatrixErrorResponse{
 				Status: http.StatusInternalServerError,
 				ErrCode: "M_UNKNOWN",


### PR DESCRIPTION
I was running into the error `Unable to create room on SFU` and couldn't figure out why. I ended up tracing it to the code here and found the silenced errors so thought I would add these log calls. They immediately helped me figure out that I had forwarded the wrong port on my reverse proxy, causing 502 bad gateway error.