### PR TITLE
feat(healthcheck): error messages & use `localhost` instead of static ip (`ipv4` & `ipv6` compatibility)

### DIFF
--- a/healthcheck/main.go
+++ b/healthcheck/main.go
@@ -18,13 +18,14 @@ func main() {
 		lkJwtBind = "8080"
 	}
 
-	healthUrl := fmt.Sprintf("http://127.0.0.1:%s/healthz", lkJwtBind)
-	resp, err := http.Get(healthUrl)
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/healthz", lkJwtBind))
 	if err != nil {
+		fmt.Println("Connection error:", err)
 		os.Exit(1)
 	}
 
 	if resp.StatusCode != 200 {
+		fmt.Println("Healthcheck failed with status code", resp.StatusCode)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- additional error messages (will not hurt)
- use localhost instead of static ip (`127.0.0.1`) for ipv6 support
- a bit more resource friendly by avoiding a var (ram is expensive these days!! :rofl:)

See also #186 