### PR TITLE
Allow participants to update their own metadata

### DIFF
--- a/get_token_test.go
+++ b/get_token_test.go
@@ -144,6 +144,9 @@ func TestHandleGetToken_Success(t *testing.T) {
 	if got := claims["video"].(map[string]interface{})["room"]; got != wantRoom {
 		t.Errorf("room = %v, want %v", got, wantRoom)
 	}
+	if got := claims["video"].(map[string]interface{})["canUpdateOwnMetadata"]; got != true {
+		t.Errorf("canUpdateOwnMetadata = %v, want true", got)
+	}
 }
 
 // TestHandleGetToken_UnauthorizedUser verifies that a mismatch between the

--- a/handler.go
+++ b/handler.go
@@ -67,12 +67,14 @@ func getJoinToken(apiKey string, apiSecret string, room LiveKitRoomAlias, identi
 
 	canPublish := true
 	canSubscribe := true
+	canUpdateOwnMetadata := true
 	grant := &auth.VideoGrant{
-		RoomJoin:     true,
-		RoomCreate:   false,
-		CanPublish:   &canPublish,
-		CanSubscribe: &canSubscribe,
-		Room:         string(room),
+		RoomJoin:             true,
+		RoomCreate:           false,
+		CanPublish:           &canPublish,
+		CanSubscribe:         &canSubscribe,
+		CanUpdateOwnMetadata: &canUpdateOwnMetadata,
+		Room:                 string(room),
 	}
 
 	at.SetVideoGrant(grant).

--- a/integration-tests/tests/get_token.rs
+++ b/integration-tests/tests/get_token.rs
@@ -287,12 +287,17 @@ async fn full_access_token() {
     assert_eq!(response["url"].as_str(), Some(sfu.url()));
     let jwt = response["jwt"].as_str().unwrap_or_default();
 
-    // The JWT should grant joining plus publishing and subscribing.
+    // The JWT should grant joining plus publishing, subscribing and
+    // updating the participant's own metadata.
     let claims = decode_livekit_jwt(jwt);
     assert_eq!(claims["iss"].as_str(), Some(LIVEKIT_KEY));
     assert_eq!(claims["video"]["roomJoin"].as_bool(), Some(true));
     assert_eq!(claims["video"]["canPublish"].as_bool(), Some(true));
     assert_eq!(claims["video"]["canSubscribe"].as_bool(), Some(true));
+    assert_eq!(
+        claims["video"]["canUpdateOwnMetadata"].as_bool(),
+        Some(true)
+    );
     assert!(
         !claims["sub"].as_str().unwrap_or_default().is_empty(),
         "expected a non-empty identity, got {claims}"
@@ -347,12 +352,17 @@ async fn remote_token() {
     assert_eq!(response["url"].as_str(), Some(sfu.url()));
     let jwt = response["jwt"].as_str().unwrap_or_default();
 
-    // The JWT should grant joining plus publishing and subscribing.
+    // The JWT should grant joining plus publishing, subscribing and
+    // updating the participant's own metadata.
     let claims = decode_livekit_jwt(jwt);
     assert_eq!(claims["iss"].as_str(), Some(LIVEKIT_KEY));
     assert_eq!(claims["video"]["roomJoin"].as_bool(), Some(true));
     assert_eq!(claims["video"]["canPublish"].as_bool(), Some(true));
     assert_eq!(claims["video"]["canSubscribe"].as_bool(), Some(true));
+    assert_eq!(
+        claims["video"]["canUpdateOwnMetadata"].as_bool(),
+        Some(true)
+    );
     assert!(
         !claims["sub"].as_str().unwrap_or_default().is_empty(),
         "expected a non-empty identity, got {claims}"


### PR DESCRIPTION
## Why

LiveKit agent sessions publish their listening, thinking, and speaking state through participant metadata. Tokens minted by the MatrixRTC authorization service currently omit the permission required to update that metadata, so these state updates are rejected by the SFU.

## What changed

- Grant authenticated participants permission to update only their own metadata.
- Assert the claim in the existing token endpoint test.

## Validation

- go test ./...