### PR TITLE
Fix healthcheck querying invalid URLs, and failing

### DIFF
--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -18,8 +18,8 @@ async fn main() -> Result<(), String> {
     let lk_jwt_bind = parse_bind()?;
     let addrs = bind_addresses(&lk_jwt_bind);
 
-    for addr in addrs.to_vec() {
-        if let Ok(resp) = reqwest::get(get_healthz_url(&addr)).await {
+    for addr in &addrs {
+        if let Ok(resp) = reqwest::get(get_healthz_url(addr)).await {
             if resp.status().as_u16() != 200 {
                 return Err(format!(
                     "Healthcheck failed with status code {}",

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -50,7 +50,10 @@ mod tests {
 
         let url = url_res.unwrap();
         assert_eq!(url.host_str().unwrap_or("0.0.0.0"), expected_host);
-        assert_eq!(url.port_or_known_default().unwrap_or_default(), expected_port);
+        assert_eq!(
+            url.port_or_known_default().unwrap_or_default(),
+            expected_port
+        );
     }
 
     fn test_healthz_url(lk_jwt_bind: &str, expected_host: &str, expected_port: u16) {
@@ -72,7 +75,7 @@ mod tests {
         test_healthz_url("127.0.0.1:8080", "127.0.0.1", 8080);
         test_healthz_url("127.0.0.1:443", "127.0.0.1", 443);
     }
-    
+
     #[test]
     fn bind_all_invalid() {
         let addrs = bind_addresses("8080");

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -6,26 +6,30 @@
 //! Container health check: GETs /healthz on the local service and exits
 //! non-zero on failure.
 
-#[tokio::main]
-async fn main() {
-    let mut lk_jwt_bind = std::env::var("LIVEKIT_JWT_BIND").unwrap_or_default();
-    if lk_jwt_bind.is_empty() {
-        lk_jwt_bind = "8080".into();
-    }
+use lk_jwt_service::config::{bind_addresses, parse_config};
 
-    let resp = match reqwest::get(format!("http://localhost:{lk_jwt_bind}/healthz")).await {
-        Ok(resp) => resp,
-        Err(err) => {
-            println!("Connection error: {err}");
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let config = parse_config()?;
+    let addrs = bind_addresses(&config.lk_jwt_bind);
+
+    for addr in addrs {
+        let resp = match reqwest::get(format!("http://{addr}/healthz")).await {
+            Ok(resp) => resp,
+            Err(err) => {
+                println!("Connection error: {err}");
+                std::process::exit(1);
+            }
+        };
+
+        if resp.status().as_u16() != 200 {
+            println!(
+                "Healthcheck failed with status code {}",
+                resp.status().as_u16()
+            );
             std::process::exit(1);
         }
-    };
-
-    if resp.status().as_u16() != 200 {
-        println!(
-            "Healthcheck failed with status code {}",
-            resp.status().as_u16()
-        );
-        std::process::exit(1);
     }
+
+    Ok(())
 }

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -6,12 +6,12 @@
 //! Container health check: GETs /healthz on the local service and exits
 //! non-zero on failure.
 
-use lk_jwt_service::config::{bind_addresses, parse_config};
+use lk_jwt_service::config::{bind_addresses, parse_bind};
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    let config = parse_config()?;
-    let addrs = bind_addresses(&config.lk_jwt_bind);
+    let lk_jwt_bind = parse_bind()?;
+    let addrs = bind_addresses(&lk_jwt_bind);
 
     for addr in addrs {
         let resp = match reqwest::get(format!("http://{addr}/healthz")).await {

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -21,11 +21,10 @@ async fn main() -> Result<(), String> {
     for addr in addrs.to_vec() {
         if let Ok(resp) = reqwest::get(get_healthz_url(&addr)).await {
             if resp.status().as_u16() != 200 {
-                println!(
+                return Err(format!(
                     "Healthcheck failed with status code {}",
                     resp.status().as_u16()
-                );
-                std::process::exit(1);
+                ));
             }
 
             return Ok(());

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -8,13 +8,18 @@
 
 use lk_jwt_service::config::{bind_addresses, parse_bind};
 
+#[inline]
+fn get_healthz_url(host_and_port: &str) -> String {
+    format!("http://{host_and_port}/healthz")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let lk_jwt_bind = parse_bind()?;
     let addrs = bind_addresses(&lk_jwt_bind);
 
     for addr in addrs {
-        let resp = match reqwest::get(format!("http://{addr}/healthz")).await {
+        let resp = match reqwest::get(get_healthz_url(&addr)).await {
             Ok(resp) => resp,
             Err(err) => {
                 println!("Connection error: {err}");
@@ -32,4 +37,46 @@ async fn main() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn validate_url(url_str: &str, expected_host: &str, expected_port: u16) {
+        let url_res = Url::parse(url_str);
+        assert!(url_res.is_ok());
+
+        let url = url_res.unwrap();
+        assert_eq!(url.host_str().unwrap_or("0.0.0.0"), expected_host);
+        assert_eq!(url.port_or_known_default().unwrap_or_default(), expected_port);
+    }
+
+    fn test_healthz_url(lk_jwt_bind: &str, expected_host: &str, expected_port: u16) {
+        let addrs = bind_addresses(lk_jwt_bind);
+        let last = addrs.last().expect("bind_addresses returned empty Vec");
+        let url_str = get_healthz_url(last);
+        validate_url(&url_str, expected_host, expected_port);
+    }
+
+    #[test]
+    fn bind_all_valid() {
+        test_healthz_url(":8080", "0.0.0.0", 8080);
+        test_healthz_url(":1234", "0.0.0.0", 1234);
+        test_healthz_url(":443", "0.0.0.0", 443);
+    }
+
+    #[test]
+    fn bind_specific_valid() {
+        test_healthz_url("127.0.0.1:8080", "127.0.0.1", 8080);
+        test_healthz_url("127.0.0.1:443", "127.0.0.1", 443);
+    }
+    
+    #[test]
+    fn bind_all_invalid() {
+        let addrs = bind_addresses("8080");
+        let last = addrs.last().expect("bind_addresses returned empty Vec");
+        assert!(Url::parse(last).is_err());
+    }
 }

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -18,25 +18,24 @@ async fn main() -> Result<(), String> {
     let lk_jwt_bind = parse_bind()?;
     let addrs = bind_addresses(&lk_jwt_bind);
 
-    for addr in addrs {
-        let resp = match reqwest::get(get_healthz_url(&addr)).await {
-            Ok(resp) => resp,
-            Err(err) => {
-                println!("Connection error: {err}");
+    for addr in addrs.to_vec() {
+        if let Ok(resp) = reqwest::get(get_healthz_url(&addr)).await {
+            if resp.status().as_u16() != 200 {
+                println!(
+                    "Healthcheck failed with status code {}",
+                    resp.status().as_u16()
+                );
                 std::process::exit(1);
             }
-        };
 
-        if resp.status().as_u16() != 200 {
-            println!(
-                "Healthcheck failed with status code {}",
-                resp.status().as_u16()
-            );
-            std::process::exit(1);
+            return Ok(());
         }
     }
 
-    Ok(())
+    let addrs_fmt = addrs.join(", ");
+    Err(format!(
+        "No configured address ({addrs_fmt}) could be accessed"
+    ))
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,24 @@ pub fn read_cs_api_url_overrides(raw: &str) -> Result<HashMap<String, CsApiUrl>,
     Ok(m)
 }
 
+pub fn parse_bind() -> Result<String, String> {
+    let mut lk_jwt_bind = env_var("LIVEKIT_JWT_BIND");
+    let mut lk_jwt_port = env_var("LIVEKIT_JWT_PORT");
+
+    if lk_jwt_bind.is_empty() {
+        if lk_jwt_port.is_empty() {
+            lk_jwt_port = "8080".into();
+        } else {
+            warn!("!!! LIVEKIT_JWT_PORT is deprecated, use LIVEKIT_JWT_BIND !!!");
+        }
+        lk_jwt_bind = format!(":{lk_jwt_port}");
+    } else if !lk_jwt_port.is_empty() {
+        return Err("LIVEKIT_JWT_BIND and LIVEKIT_JWT_PORT must not be set together".into());
+    }
+
+    Ok(lk_jwt_bind)
+}
+
 pub fn parse_config() -> Result<Config, String> {
     let skip_verify_tls =
         env_var("LIVEKIT_INSECURE_SKIP_VERIFY_TLS") == "YES_I_KNOW_WHAT_I_AM_DOING";
@@ -121,18 +139,7 @@ pub fn parse_config() -> Result<Config, String> {
         return Err("LIVEKIT_FULL_ACCESS_HOMESERVERS environment variable must be set to the homeserver(s) you intend to serve — see README for guidance".into());
     }
 
-    let mut lk_jwt_bind = env_var("LIVEKIT_JWT_BIND");
-    let mut lk_jwt_port = env_var("LIVEKIT_JWT_PORT");
-    if lk_jwt_bind.is_empty() {
-        if lk_jwt_port.is_empty() {
-            lk_jwt_port = "8080".into();
-        } else {
-            warn!("!!! LIVEKIT_JWT_PORT is deprecated, use LIVEKIT_JWT_BIND !!!");
-        }
-        lk_jwt_bind = format!(":{lk_jwt_port}");
-    } else if !lk_jwt_port.is_empty() {
-        return Err("LIVEKIT_JWT_BIND and LIVEKIT_JWT_PORT must not be set together".into());
-    }
+    let lk_jwt_bind = parse_bind()?;
 
     let mut sanity_check_interval = Duration::ZERO;
     let sanity_check_raw = env_var("LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS");


### PR DESCRIPTION
Fixes #210, the healthcheck fails because the default LIVEKIT_JWT_BIND value is `:8080`, which means "all addresses for all address families on port 8080", but then this gets formatted into `http://localhost::8080/healthz`, which is not a valid URL. We now reuse the parsing logic from `config.rs`, so the logic stays consistent.