### PR TITLE
docs: clarify latest vs latest-ci Docker tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Releases are available
 docker run -e LIVEKIT_URL="ws://somewhere" -e LIVEKIT_KEY=devkey -e LIVEKIT_SECRET=secret -e LIVEKIT_FULL_ACCESS_HOMESERVERS=example.com -p 8080:8080 ghcr.io/element-hq/lk-jwt-service:latest
 ```
 
+> **Which tag?** `latest` points at the most recent tagged
+> [release](https://github.com/element-hq/lk-jwt-service/releases).
+> `latest-ci` is a rolling build of `main`: it picks up every change
+> immediately but may be unstable — use it only if you are comfortable
+> running code that is under active development.
+
 ### 📦 From Release
 
 1. Download & mark as executable (example is amd64, replace with arm64 if needed):


### PR DESCRIPTION
Per the discussion in #208: the README's "🐳 From Docker Image" section recommends `latest` without noting that it only moves on a tagged release, while `latest-ci` tracks `main`. During a long release gap this makes a missing feature on `latest` look like a broken image.

Adds a short note distinguishing the two tags right after the `docker run` example.

Fixes: #208