### PR TITLE
Adapt error codes to MSC

### DIFF
--- a/e2e-tests/tests/get_token.rs
+++ b/e2e-tests/tests/get_token.rs
@@ -266,8 +266,8 @@ async fn get_token_rejects_when_remote_server_is_not_joined() {
 
     assert_eq!(
         status.as_u16(),
-        502,
-        "expected 502 when the remote homeserver isn't in the room, got {status}: {body}"
+        403,
+        "expected the remote homeserver's 403 to be relayed, got {status}: {body}"
     );
-    assert_eq!(body["errcode"].as_str(), Some("M_CONNECTION_FAILED"));
+    assert_eq!(body["errcode"].as_str(), Some("M_FORBIDDEN"));
 }

--- a/integration-tests/tests/get_token_cs.rs
+++ b/integration-tests/tests/get_token_cs.rs
@@ -489,13 +489,16 @@ async fn non_member_is_rejected_even_with_foreign_server_name() {
     expect_no_fed_proxy_requests(&hs);
 }
 
-/// A destination-side error relayed through the federation proxy surfaces
-/// as a 502 to the original caller.
+/// An HTTP 403 / M_FORBIDDEN response from the destination homeserver is relayed
+/// to the original caller verbatim.
 #[tokio::test]
-async fn federation_proxy_destination_error_surfaces_as_502() {
+async fn federation_proxy_forbidden_is_relayed_to_client() {
     let hs = FakeHomeserver::new().await;
     let user = hs.new_user("alice");
-    hs.set_fed_proxy_response(403, None);
+    hs.set_fed_proxy_response(
+        403,
+        Some(json!({"errcode": "M_FORBIDDEN", "error": "not a member"})),
+    );
     let destination_hs = FakeHomeserver::new().await;
 
     let mut cs_api_url_overrides = hs.cs_api_url_override();
@@ -513,7 +516,108 @@ async fn federation_proxy_destination_error_surfaces_as_502() {
     request["server_name"] = json!(destination_hs.server_name());
     let (status, body) = post_get_token_cs(&svc, request.to_string(), Some(&user.user_id)).await;
 
-    expect_matrix_error(status, &body, 502, "M_CONNECTION_FAILED");
+    expect_matrix_error(status, &body, 403, "M_FORBIDDEN");
+    expect_fed_proxy_request(
+        &hs,
+        destination_hs.server_name(),
+        AS_TOKEN,
+        &expected_relayed_body(&user.user_id, DEFAULT_LK_URL),
+    );
+}
+
+/// An HTTP 400 / M_INVALID_PARAM response from the destination homeserver is relayed
+/// to the original caller verbatim.
+#[tokio::test]
+async fn federation_proxy_invalid_param_is_relayed_to_client() {
+    let hs = FakeHomeserver::new().await;
+    let user = hs.new_user("alice");
+    hs.set_fed_proxy_response(
+        400,
+        Some(json!({"errcode": "M_INVALID_PARAM", "error": "unknown SFU url"})),
+    );
+    let destination_hs = FakeHomeserver::new().await;
+
+    let mut cs_api_url_overrides = hs.cs_api_url_override();
+    cs_api_url_overrides.extend(destination_hs.cs_api_url_override());
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        cs_api_url_overrides,
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let mut request = get_token_cs_request(&user.user_id, DEFAULT_LK_URL);
+    request["server_name"] = json!(destination_hs.server_name());
+    let (status, body) = post_get_token_cs(&svc, request.to_string(), Some(&user.user_id)).await;
+
+    expect_matrix_error(status, &body, 400, "M_INVALID_PARAM");
+    expect_fed_proxy_request(
+        &hs,
+        destination_hs.server_name(),
+        AS_TOKEN,
+        &expected_relayed_body(&user.user_id, DEFAULT_LK_URL),
+    );
+}
+
+/// A destination error status outside 403/400 surfaces as 502 / M_UNKNOWN
+/// rather than being relayed verbatim.
+#[tokio::test]
+async fn federation_proxy_other_destination_error_surfaces_as_502() {
+    let hs = FakeHomeserver::new().await;
+    let user = hs.new_user("alice");
+    hs.set_fed_proxy_response(500, None);
+    let destination_hs = FakeHomeserver::new().await;
+
+    let mut cs_api_url_overrides = hs.cs_api_url_override();
+    cs_api_url_overrides.extend(destination_hs.cs_api_url_override());
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        cs_api_url_overrides,
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let mut request = get_token_cs_request(&user.user_id, DEFAULT_LK_URL);
+    request["server_name"] = json!(destination_hs.server_name());
+    let (status, body) = post_get_token_cs(&svc, request.to_string(), Some(&user.user_id)).await;
+
+    expect_matrix_error(status, &body, 502, "M_UNKNOWN");
+    expect_fed_proxy_request(
+        &hs,
+        destination_hs.server_name(),
+        AS_TOKEN,
+        &expected_relayed_body(&user.user_id, DEFAULT_LK_URL),
+    );
+}
+
+/// A 403 whose errcode isn't M_FORBIDDEN is not relayed as such and instead results in 502.
+#[tokio::test]
+async fn federation_proxy_403_with_unexpected_errcode_surfaces_as_502() {
+    let hs = FakeHomeserver::new().await;
+    let user = hs.new_user("alice");
+    hs.set_fed_proxy_response(403, Some(json!({"errcode": "M_FOOBAR", "error": "?"})));
+    let destination_hs = FakeHomeserver::new().await;
+
+    let mut cs_api_url_overrides = hs.cs_api_url_override();
+    cs_api_url_overrides.extend(destination_hs.cs_api_url_override());
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        cs_api_url_overrides,
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let mut request = get_token_cs_request(&user.user_id, DEFAULT_LK_URL);
+    request["server_name"] = json!(destination_hs.server_name());
+    let (status, body) = post_get_token_cs(&svc, request.to_string(), Some(&user.user_id)).await;
+
+    expect_matrix_error(status, &body, 502, "M_UNKNOWN");
     expect_fed_proxy_request(
         &hs,
         destination_hs.server_name(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -33,8 +33,9 @@ use crate::delayed_event_manager::{
 #[cfg(feature = "appservice-ping-trigger")]
 use crate::helper::new_unique_id;
 use crate::helper::{
-    CsApiUrl, CsApiUrlCache, Deps, GET_TOKEN_SS_PATH, LiveKitAuth, LiveKitIdentity,
-    LiveKitRoomAlias, UniqueId, livekit_identity_for, livekit_room_alias_for, matrix_server_name,
+    CsApiUrl, CsApiUrlCache, Deps, FederationTokenError, GET_TOKEN_SS_PATH, LiveKitAuth,
+    LiveKitIdentity, LiveKitRoomAlias, UniqueId, livekit_identity_for, livekit_room_alias_for,
+    matrix_server_name,
 };
 #[cfg(feature = "appservice-ping-trigger")]
 use crate::requests::AppservicePingTriggerRequest;
@@ -1021,7 +1022,7 @@ impl Handler {
                     "Handler: error checking room membership");
                 MatrixErrorResponse {
                     status: 502,
-                    errcode: "M_CONNECTION_FAILED".into(),
+                    errcode: "M_UNKNOWN".into(),
                     err: "Unable to verify room membership".into(),
                 }
             })?;
@@ -1075,11 +1076,7 @@ impl Handler {
                 .map_err(|err| {
                     error!(matrix_id = %mxid_header, destination = %target_server_name, err = %err,
                         "Handler: error relaying get_token via federation proxy");
-                    MatrixErrorResponse {
-                        status: 502,
-                        errcode: "M_CONNECTION_FAILED".into(),
-                        err: "Unable to reach the specified homeserver".into(),
-                    }
+                    matrix_error_for_federation_token(err)
                 })?;
 
             info!(matrix_id = %mxid_header, destination = %target_server_name,
@@ -1104,7 +1101,7 @@ impl Handler {
 
         let membership_error = || MatrixErrorResponse {
             status: 502,
-            errcode: "M_CONNECTION_FAILED".into(),
+            errcode: "M_UNKNOWN".into(),
             err: "Unable to verify room membership".into(),
         };
 
@@ -1296,6 +1293,34 @@ impl Handler {
         }
 
         router.with_state(self.clone())
+    }
+}
+
+/// Maps a `/get_token` federation relay failure to the client response.
+fn matrix_error_for_federation_token(err: FederationTokenError) -> MatrixErrorResponse {
+    match err {
+        FederationTokenError::Destination {
+            status: 403,
+            errcode,
+        } if errcode == "M_FORBIDDEN" => MatrixErrorResponse {
+            status: 403,
+            errcode,
+            err: "The requesting user is not a member of the room on the destination homeserver"
+                .into(),
+        },
+        FederationTokenError::Destination {
+            status: 400,
+            errcode,
+        } if errcode == "M_INVALID_PARAM" => MatrixErrorResponse {
+            status: 400,
+            errcode,
+            err: "The destination homeserver rejected the specified `url`".into(),
+        },
+        _ => MatrixErrorResponse {
+            status: 502,
+            errcode: "M_UNKNOWN".into(),
+            err: "Unable to reach the specified homeserver".into(),
+        },
     }
 }
 
@@ -1528,7 +1553,7 @@ async fn handle_appservice_ping_trigger(
                 "Handler: appservice ping trigger: could not resolve C-S API URL");
             return matrix_error_response(
                 502,
-                "M_CONNECTION_FAILED",
+                "M_UNKNOWN",
                 &format!("Could not resolve C-S API URL: {err}"),
             );
         }
@@ -1555,7 +1580,7 @@ async fn handle_appservice_ping_trigger(
                 "Handler: appservice ping trigger: request failed");
             matrix_error_response(
                 502,
-                "M_CONNECTION_FAILED",
+                "M_UNKNOWN",
                 &format!("Failed to reach homeserver: {err}"),
             )
         }

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -42,7 +42,9 @@ type GetDelayedEventDelayFn =
     Box<dyn Fn(&CsApiUrl, &str, &str, &str) -> Result<Duration, ActionError> + Send + Sync>;
 type IsJoinedFn = Box<dyn Fn(&CsApiUrl, &str, &str) -> Result<bool, String> + Send + Sync>;
 type RequestGetTokenViaFederationFn = Box<
-    dyn Fn(&CsApiUrl, &str, &GetTokenSsRequest) -> Result<GetTokenSsResponse, String> + Send + Sync,
+    dyn Fn(&CsApiUrl, &str, &GetTokenSsRequest) -> Result<GetTokenSsResponse, FederationTokenError>
+        + Send
+        + Sync,
 >;
 
 /// A [`Deps`] implementation with per-test swappable behaviours. Un-mocked
@@ -181,7 +183,7 @@ impl Deps for HandlerTestDeps {
         _as_token: &str,
         destination: &str,
         req: &GetTokenSsRequest,
-    ) -> Result<GetTokenSsResponse, String> {
+    ) -> Result<GetTokenSsResponse, FederationTokenError> {
         match &self.request_get_token_via_federation_fn {
             Some(f) => f(own_cs_api_url, destination, req),
             None => panic!("request_get_token_via_federation not mocked in HandlerTestDeps"),
@@ -2340,7 +2342,7 @@ async fn test_handle_get_token_cs_relays_foreign_server_name() {
     handler.close().await;
 }
 
-/// A transport error from the federation proxy surfaces as 502.
+/// A transport error from the federation proxy surfaces as 502 / M_UNKNOWN.
 #[tokio::test]
 async fn test_handle_get_token_cs_federation_proxy_error() {
     let deps = HandlerTestDeps {
@@ -2348,7 +2350,9 @@ async fn test_handle_get_token_cs_federation_proxy_error() {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
         is_user_joined_fn: is_joined_ok(true),
-        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| Err("boom".into()))),
+        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| {
+            Err(FederationTokenError::Other("boom".into()))
+        })),
         ..Default::default()
     };
     let handler = new_get_token_cs_handler(deps);
@@ -2361,6 +2365,146 @@ async fn test_handle_get_token_cs_federation_proxy_error() {
         StatusCode::BAD_GATEWAY,
         "expected 502 when the federation proxy fails"
     );
+    let body = body_bytes(resp).await;
+    let matrix_err: MatrixErrorBody =
+        serde_json::from_slice(&body).expect("failed to decode response body");
+    assert_eq!(matrix_err.errcode, "M_UNKNOWN", "unexpected error code");
+    handler.close().await;
+}
+
+/// 403 / M_FORBIDDEN from the destination is relayed verbatim.
+#[tokio::test]
+async fn test_handle_get_token_cs_federation_relays_forbidden() {
+    let deps = HandlerTestDeps {
+        resolve_cs_api_url_fn: Some(Box::new(|_| {
+            Ok(CsApiUrl("https://matrix.example.com".into()))
+        })),
+        is_user_joined_fn: is_joined_ok(true),
+        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| {
+            Err(FederationTokenError::Destination {
+                status: 403,
+                errcode: "M_FORBIDDEN".into(),
+            })
+        })),
+        ..Default::default()
+    };
+    let handler = new_get_token_cs_handler(deps);
+    let body = marshal_get_token_cs_request(|r| {
+        r.server_name = "other.example.org".into();
+    });
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "expected the destination's 403 to be relayed"
+    );
+    let body = body_bytes(resp).await;
+    let matrix_err: MatrixErrorBody =
+        serde_json::from_slice(&body).expect("failed to decode response body");
+    assert_eq!(matrix_err.errcode, "M_FORBIDDEN", "unexpected error code");
+    handler.close().await;
+}
+
+/// 400 / M_INVALID_PARAM from the destination is relayed verbatim.
+#[tokio::test]
+async fn test_handle_get_token_cs_federation_relays_invalid_param() {
+    let deps = HandlerTestDeps {
+        resolve_cs_api_url_fn: Some(Box::new(|_| {
+            Ok(CsApiUrl("https://matrix.example.com".into()))
+        })),
+        is_user_joined_fn: is_joined_ok(true),
+        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| {
+            Err(FederationTokenError::Destination {
+                status: 400,
+                errcode: "M_INVALID_PARAM".into(),
+            })
+        })),
+        ..Default::default()
+    };
+    let handler = new_get_token_cs_handler(deps);
+    let body = marshal_get_token_cs_request(|r| {
+        r.server_name = "other.example.org".into();
+    });
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "expected the destination's 400 to be relayed"
+    );
+    let body = body_bytes(resp).await;
+    let matrix_err: MatrixErrorBody =
+        serde_json::from_slice(&body).expect("failed to decode response body");
+    assert_eq!(
+        matrix_err.errcode, "M_INVALID_PARAM",
+        "unexpected error code"
+    );
+    handler.close().await;
+}
+
+/// A 403 whose errcode isn't M_FORBIDDEN is not relayed as such — only the
+/// exact (status, errcode) pairs from MSC4195 are, everything else is 502.
+#[tokio::test]
+async fn test_handle_get_token_cs_federation_403_with_unexpected_errcode() {
+    let deps = HandlerTestDeps {
+        resolve_cs_api_url_fn: Some(Box::new(|_| {
+            Ok(CsApiUrl("https://matrix.example.com".into()))
+        })),
+        is_user_joined_fn: is_joined_ok(true),
+        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| {
+            Err(FederationTokenError::Destination {
+                status: 403,
+                errcode: "M_FOOBAR".into(),
+            })
+        })),
+        ..Default::default()
+    };
+    let handler = new_get_token_cs_handler(deps);
+    let body = marshal_get_token_cs_request(|r| {
+        r.server_name = "other.example.org".into();
+    });
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_GATEWAY,
+        "expected an unrecognised errcode to collapse to 502, not be relayed"
+    );
+    let body = body_bytes(resp).await;
+    let matrix_err: MatrixErrorBody =
+        serde_json::from_slice(&body).expect("failed to decode response body");
+    assert_eq!(matrix_err.errcode, "M_UNKNOWN", "unexpected error code");
+    handler.close().await;
+}
+
+/// A destination error status other than 403/400 collapses to 502 / M_UNKNOWN.
+#[tokio::test]
+async fn test_handle_get_token_cs_federation_other_destination_error() {
+    let deps = HandlerTestDeps {
+        resolve_cs_api_url_fn: Some(Box::new(|_| {
+            Ok(CsApiUrl("https://matrix.example.com".into()))
+        })),
+        is_user_joined_fn: is_joined_ok(true),
+        request_get_token_via_federation_fn: Some(Box::new(|_, _, _| {
+            Err(FederationTokenError::Destination {
+                status: 500,
+                errcode: "M_UNKNOWN".into(),
+            })
+        })),
+        ..Default::default()
+    };
+    let handler = new_get_token_cs_handler(deps);
+    let body = marshal_get_token_cs_request(|r| {
+        r.server_name = "other.example.org".into();
+    });
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_GATEWAY,
+        "expected an unlisted destination status to collapse to 502"
+    );
+    let body = body_bytes(resp).await;
+    let matrix_err: MatrixErrorBody =
+        serde_json::from_slice(&body).expect("failed to decode response body");
+    assert_eq!(matrix_err.errcode, "M_UNKNOWN", "unexpected error code");
     handler.close().await;
 }
 
@@ -2644,7 +2788,7 @@ async fn test_process_get_token_cs_request() {
                     "unexpected fed_proxy destination"
                 );
                 if fail_fed_proxy {
-                    Err("boom".into())
+                    Err(FederationTokenError::Other("boom".into()))
                 } else {
                     Ok(GetTokenSsResponse {
                         jwt: "remote-jwt".into(),

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -535,6 +535,17 @@ impl IsJoinedSubject<'_> {
     }
 }
 
+/// The outcome of a failed `/get_token` federation relay: either the
+/// destination homeserver rejected the request (`status` and `errcode` as
+/// reported by it), or something else went wrong reaching it.
+#[derive(Debug, thiserror::Error)]
+pub enum FederationTokenError {
+    #[error("destination homeserver returned http status code {status} ({errcode})")]
+    Destination { status: u16, errcode: String },
+    #[error("{0}")]
+    Other(String),
+}
+
 // ── Deps: the swappable dependency surface ───────────────────────────────────
 
 /// External interactions of the service. The real logic lives in the default
@@ -1057,12 +1068,17 @@ pub trait Deps: Send + Sync {
         as_token: &str,
         destination: &str,
         req: &GetTokenSsRequest,
-    ) -> Result<GetTokenSsResponse, String> {
-        let mut endpoint = url::Url::parse(own_cs_api_url.as_str())
-            .map_err(|e| format!("invalid client-server API URL: {e}"))?;
+    ) -> Result<GetTokenSsResponse, FederationTokenError> {
+        let mut endpoint = url::Url::parse(own_cs_api_url.as_str()).map_err(|e| {
+            FederationTokenError::Other(format!("invalid client-server API URL: {e}"))
+        })?;
         endpoint
             .path_segments_mut()
-            .map_err(|_| "invalid client-server API URL: cannot be a base".to_string())?
+            .map_err(|_| {
+                FederationTokenError::Other(
+                    "invalid client-server API URL: cannot be a base".into(),
+                )
+            })?
             .pop_if_empty()
             .extend([
                 "_matrix",
@@ -1088,38 +1104,51 @@ pub trait Deps: Send + Sync {
             .map_err(|e| {
                 let msg = error_chain(&e);
                 debug!(url = %endpoint, err = %msg, "request_get_token_via_federation");
-                format!("failed to reach the federation proxy: {msg}")
+                FederationTokenError::Other(format!("failed to reach the federation proxy: {msg}"))
             })?;
 
         let status = resp.status();
         if !status.is_success() {
-            return Err(format!(
+            return Err(FederationTokenError::Other(format!(
                 "federation proxy request failed: http status code {}",
                 status.as_u16()
-            ));
+            )));
         }
 
+        // `content` is left untyped here: on a destination-side error it's a
+        // Matrix error body ({errcode, error}), not a GetTokenSsResponse.
         #[derive(Deserialize)]
         struct FedProxyResponse {
             status: u16,
             #[serde(default)]
-            content: Option<GetTokenSsResponse>,
+            content: Option<serde_json::Value>,
         }
-        let parsed: FedProxyResponse = resp
-            .json()
-            .await
-            .map_err(|e| format!("failed to parse federation proxy response: {e}"))?;
+        let parsed: FedProxyResponse = resp.json().await.map_err(|e| {
+            FederationTokenError::Other(format!("failed to parse federation proxy response: {e}"))
+        })?;
 
         if !(200..300).contains(&parsed.status) {
-            return Err(format!(
-                "destination homeserver returned http status code {}",
-                parsed.status
-            ));
+            let errcode = parsed
+                .content
+                .as_ref()
+                .and_then(|c| c.get("errcode"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            return Err(FederationTokenError::Destination {
+                status: parsed.status,
+                errcode,
+            });
         }
 
-        parsed
-            .content
-            .ok_or_else(|| "destination homeserver returned an empty response".to_string())
+        let content = parsed.content.ok_or_else(|| {
+            FederationTokenError::Other("destination homeserver returned an empty response".into())
+        })?;
+        serde_json::from_value(content).map_err(|e| {
+            FederationTokenError::Other(format!(
+                "failed to parse destination homeserver response: {e}"
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
This adapts the used error codes to the latest state of https://github.com/matrix-org/matrix-spec-proposals/pull/4195.