### PR TITLE
Create LiveKit rooms on remote token requests, too

### DIFF
--- a/integration-tests/tests/get_token_ss.rs
+++ b/integration-tests/tests/get_token_ss.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use lk_jwt_service_integration_tests::{
-    DEFAULT_LK_URL, FakeHomeserver, Service, ServiceConfig, decode_livekit_jwt,
+    DEFAULT_LK_URL, FakeHomeserver, FakeSfu, Service, ServiceConfig, decode_livekit_jwt,
     expect_matrix_error, expect_server_is_joined_request,
 };
 use serde_json::{Value, json};
@@ -190,14 +190,17 @@ async fn get_instead_of_post() {
 }
 
 /// A valid request from a joined origin server, for a room our own server
-/// is also joined to, succeeds and both memberships are verified.
+/// is also joined to, succeeds, both memberships are verified, and the
+/// LiveKit room is created.
 #[tokio::test]
 async fn success() {
     let hs = FakeHomeserver::new().await;
+    let sfu = FakeSfu::new().await;
 
     let svc = Service::start(ServiceConfig {
         full_access_homeservers: vec!["*".to_owned()],
         cs_api_url_overrides: hs.cs_api_url_override(),
+        livekit_url: Some(sfu.url().to_owned()),
         extra_env: app_service_env(hs.server_name()),
         ..Default::default()
     })
@@ -205,7 +208,7 @@ async fn success() {
 
     let (status, body) = post_get_token_ss(
         &svc,
-        get_token_ss_request("@alice:origin.example.org", DEFAULT_LK_URL).to_string(),
+        get_token_ss_request("@alice:origin.example.org", sfu.url()).to_string(),
         Some(ORIGIN_SERVER),
         Some(HS_TOKEN),
     )
@@ -217,11 +220,19 @@ async fn success() {
 
     let claims = decode_livekit_jwt(jwt);
     assert_eq!(claims["video"]["roomJoin"].as_bool(), Some(true));
+    assert_eq!(claims["video"]["roomCreate"].as_bool(), Some(false));
     assert_eq!(claims["video"]["canPublish"].as_bool(), Some(false));
     assert_eq!(claims["video"]["canSubscribe"].as_bool(), Some(true));
 
     expect_server_is_joined_request(&hs, "!room:example.com", hs.server_name(), AS_TOKEN);
     expect_server_is_joined_request(&hs, "!room:example.com", ORIGIN_SERVER, AS_TOKEN);
+
+    let rooms = sfu.create_room_requests();
+    assert_eq!(rooms.len(), 1, "expected exactly one room creation");
+    assert_eq!(
+        claims["video"]["room"].as_str(),
+        Some(rooms[0].name.as_str())
+    );
 }
 
 /// A request is rejected when our own server is not joined to the room.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1161,6 +1161,9 @@ impl Handler {
             false,
         )?;
 
+        self.create_livekit_room_or_internal_error(&lk_room_alias, &req.user_id, &lk_identity)
+            .await?;
+
         info!(user_id = %req.user_id, claimed_device_id = %req.member.claimed_device_id,
             origin = %origin_header, matrix_room = %req.room_id, matrix_rtc_slot = %req.slot_id,
             lk_id = %lk_identity, room = %lk_room_alias,

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -2885,11 +2885,17 @@ async fn test_handle_get_token_ss_url_mismatch() {
 /// A valid request produces a 200 response.
 #[tokio::test]
 async fn test_handle_get_token_ss_success() {
+    let create_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let create_called_clone = create_called.clone();
     let deps = HandlerTestDeps {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
         is_server_joined_fn: Some(Box::new(|_, _, _| Ok(true))),
+        create_livekit_room_fn: Some(Box::new(move |_, _, _| {
+            create_called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        })),
         ..Default::default()
     };
     let handler = new_get_token_ss_handler(deps);
@@ -2900,6 +2906,10 @@ async fn test_handle_get_token_ss_success() {
     )
     .await;
     assert_eq!(resp.status(), StatusCode::OK, "status");
+    assert!(
+        create_called.load(std::sync::atomic::Ordering::SeqCst),
+        "expected create_livekit_room to be called for the S-S endpoint"
+    );
 
     let body = body_bytes(resp).await;
     let response: GetTokenSsResponse =
@@ -3027,6 +3037,7 @@ async fn test_process_get_token_ss_request() {
         own_is_member: bool,
         origin_is_member: bool,
         fail_join_token: bool,
+        expect_create_room: bool,
         expect_error: bool,
     }
     let base = Case {
@@ -3039,11 +3050,13 @@ async fn test_process_get_token_ss_request() {
         own_is_member: true,
         origin_is_member: true,
         fail_join_token: false,
+        expect_create_room: false,
         expect_error: false,
     };
     for tc in [
         Case {
             name: "All OK",
+            expect_create_room: true,
             ..base
         },
         Case {
@@ -3095,6 +3108,9 @@ async fn test_process_get_token_ss_request() {
         let own_is_member = tc.own_is_member;
         let origin_is_member = tc.origin_is_member;
 
+        let create_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let create_called_clone = create_called.clone();
+
         let deps = HandlerTestDeps {
             resolve_cs_api_url_fn: Some(Box::new(move |_| {
                 if fail_resolution {
@@ -3115,6 +3131,10 @@ async fn test_process_get_token_ss_request() {
                 } else {
                     Ok(origin_is_member)
                 }
+            })),
+            create_livekit_room_fn: Some(Box::new(move |_, _, _| {
+                create_called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
             })),
             ..Default::default()
         };
@@ -3164,6 +3184,12 @@ async fn test_process_get_token_ss_request() {
                 tc.name
             );
         }
+        assert_eq!(
+            create_called.load(std::sync::atomic::Ordering::SeqCst),
+            tc.expect_create_room,
+            "{}: create_livekit_room called mismatch",
+            tc.name
+        );
         handler.close().await;
     }
 }


### PR DESCRIPTION
As per the MSC, the LiveKit room must always be created when requesting a token.