### PR TITLE
Update error codes for delegation endpoint

### DIFF
--- a/integration-tests/src/fake_homeserver.rs
+++ b/integration-tests/src/fake_homeserver.rs
@@ -74,9 +74,9 @@ struct HsState {
     /// The recorded /delayed_events requests.
     delayed_event_requests: Vec<DelayedEventRequest>,
 
-    /// The delay (in ms) `GET /delayed_events/{delay_id}` reports, keyed by
-    /// delay ID.
-    delays: HashMap<String, i64>,
+    /// The delay in ms and room_id that `GET /delayed_events/{delay_id}` reports,
+    /// keyed by delay ID.
+    delays: HashMap<String, (i64, String)>,
 
     /// The HTTP status to return on delayed-event look-ups, overriding the
     /// scripted delays.
@@ -237,14 +237,14 @@ impl FakeHomeserver {
         self.state.lock().unwrap().delayed_event_requests.clone()
     }
 
-    /// Makes `GET /delayed_events/{delay_id}` report the given delay for
-    /// `delay_id`.
-    pub fn set_delay(&self, delay_id: &str, delay_ms: i64) {
+    /// Makes `GET /delayed_events/{delay_id}` report the given delay and
+    /// room ID for `delay_id`.
+    pub fn set_delay(&self, delay_id: &str, delay_ms: i64, room_id: &str) {
         self.state
             .lock()
             .unwrap()
             .delays
-            .insert(delay_id.to_owned(), delay_ms);
+            .insert(delay_id.to_owned(), (delay_ms, room_id.to_owned()));
     }
 
     /// Sets the HTTP status delayed-event look-ups fail with, regardless of the
@@ -375,11 +375,11 @@ async fn handle_delayed_event_look_up(
     }
 
     match state.delays.get(&delay_id) {
-        Some(delay_ms) => (
+        Some((delay_ms, room_id)) => (
             StatusCode::OK,
             Json(json!({
                 "delay_id": delay_id,
-                "room_id": "!room:example.com",
+                "room_id": room_id,
                 "type": "m.room.member",
                 "delay_ms": delay_ms,
                 "content": {},

--- a/integration-tests/tests/delegate_delayed_leave_cs.rs
+++ b/integration-tests/tests/delegate_delayed_leave_cs.rs
@@ -330,7 +330,7 @@ async fn restart_and_send_use_identity_assertion() {
 async fn delay_timeout_looked_up_when_absent() {
     let hs = FakeHomeserver::new().await;
     let user = hs.new_user("alice");
-    hs.set_delay("syd_cs_integration_1", 8000);
+    hs.set_delay("syd_cs_integration_1", 8000, "!room:example.com");
 
     let redis = FakeRedis::new().await;
 
@@ -401,7 +401,7 @@ async fn delay_timeout_not_looked_up_when_given() {
 async fn looked_up_delay_drives_the_job() {
     let hs = FakeHomeserver::new().await;
     let user = hs.new_user("alice");
-    hs.set_delay("syd_cs_integration_1", 300);
+    hs.set_delay("syd_cs_integration_1", 300, "!room:example.com");
 
     let svc = Service::start(ServiceConfig {
         full_access_homeservers: vec!["*".to_owned()],
@@ -420,8 +420,8 @@ async fn looked_up_delay_drives_the_job() {
         .await;
 }
 
-/// An unknown delay ID is rejected with 404 M_NOT_FOUND, and no job is
-/// scheduled for it.
+/// An unknown delay ID is rejected with 400 M_INVALID_PARAM per MSC4195, and
+/// no job is scheduled for it.
 #[tokio::test]
 async fn unknown_delay_id_rejected() {
     let hs = FakeHomeserver::new().await;
@@ -440,7 +440,31 @@ async fn unknown_delay_id_rejected() {
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
 
-    expect_matrix_error(status, &body, 404, "M_NOT_FOUND");
+    expect_matrix_error(status, &body, 400, "M_INVALID_PARAM");
+    expect_no_delayed_event_requests(&hs);
+}
+
+/// A delay ID that exists but was scheduled for a different room than the
+/// one being delegated for is rejected.
+#[tokio::test]
+async fn delay_id_for_another_room_rejected() {
+    let hs = FakeHomeserver::new().await;
+    let user = hs.new_user("alice");
+    hs.set_delay("syd_cs_integration_1", 300, "!other-room:example.com");
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        cs_api_url_overrides: hs.cs_api_url_override(),
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let mut request = delegate_request();
+    request.as_object_mut().unwrap().remove("delay_timeout");
+    let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
+
+    expect_matrix_error(status, &body, 400, "M_INVALID_PARAM");
     expect_no_delayed_event_requests(&hs);
 }
 
@@ -450,7 +474,7 @@ async fn unknown_delay_id_rejected() {
 async fn delay_lookup_failure_rejected() {
     let hs = FakeHomeserver::new().await;
     let user = hs.new_user("alice");
-    hs.set_delay("syd_cs_integration_1", 8000);
+    hs.set_delay("syd_cs_integration_1", 8000, "!room:example.com");
     hs.set_delay_lookup_status(500);
 
     let svc = Service::start(ServiceConfig {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -717,17 +717,20 @@ impl Handler {
     }
 
     /// Looks up the delay of `delay_id` on the homeserver, for delegation
-    /// requests that do not carry one.
+    /// requests that do not carry one. Also verifies that the delayed event
+    /// was scheduled in `room_id`.
     async fn look_up_delay_timeout(
         &self,
         cs_api_url: &CsApiUrl,
         delay_id: &str,
+        room_id: &str,
         owner_user_id: &str,
     ) -> Result<Duration, MatrixErrorResponse> {
         self.deps
             .get_delayed_event_delay(
                 cs_api_url,
                 delay_id,
+                room_id,
                 AppServiceIdentity {
                     as_token: &self.app_service_config.as_token,
                     user_id: owner_user_id,
@@ -739,8 +742,8 @@ impl Handler {
                     "Handler: could not look up the delay of the delayed event");
                 if err.is_delayed_event_not_found() {
                     MatrixErrorResponse {
-                        status: 404,
-                        errcode: "M_NOT_FOUND".into(),
+                        status: 400,
+                        errcode: "M_INVALID_PARAM".into(),
                         err: "Unknown `delay_id`".into(),
                     }
                 } else {
@@ -1243,7 +1246,7 @@ impl Handler {
         let delay_timeout = match req.delay_timeout {
             Some(timeout) => Duration::from_millis(timeout.max(0) as u64),
             None => {
-                self.look_up_delay_timeout(&cs_api_url, &req.delay_id, mxid_header)
+                self.look_up_delay_timeout(&cs_api_url, &req.delay_id, &req.room_id, mxid_header)
                     .await?
             }
         };

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -39,7 +39,7 @@ type ExecuteDelayedEventActionFn = Box<
     dyn Fn(&CsApiUrl, &str, DelayEventAction, &str, &str) -> Result<u16, ActionError> + Send + Sync,
 >;
 type GetDelayedEventDelayFn =
-    Box<dyn Fn(&CsApiUrl, &str, &str, &str) -> Result<Duration, ActionError> + Send + Sync>;
+    Box<dyn Fn(&CsApiUrl, &str, &str, &str, &str) -> Result<Duration, ActionError> + Send + Sync>;
 type IsJoinedFn = Box<dyn Fn(&CsApiUrl, &str, &str) -> Result<bool, String> + Send + Sync>;
 type RequestGetTokenViaFederationFn = Box<
     dyn Fn(&CsApiUrl, &str, &GetTokenSsRequest) -> Result<GetTokenSsResponse, String> + Send + Sync,
@@ -141,10 +141,17 @@ impl Deps for HandlerTestDeps {
         &self,
         cs_api_url: &CsApiUrl,
         delay_id: &str,
+        room_id: &str,
         identity: AppServiceIdentity<'_>,
     ) -> Result<Duration, ActionError> {
         match &self.get_delayed_event_delay_fn {
-            Some(f) => f(cs_api_url, delay_id, identity.as_token, identity.user_id),
+            Some(f) => f(
+                cs_api_url,
+                delay_id,
+                room_id,
+                identity.as_token,
+                identity.user_id,
+            ),
             None => panic!("get_delayed_event_delay not mocked in HandlerTestDeps"),
         }
     }
@@ -4038,11 +4045,12 @@ async fn test_process_delegate_delayed_leave_cs_restart_uses_identity_assertion(
 }
 
 /// A request without a delay timeout makes the service look the delay up on
-/// the homeserver, asserting the caller's identity as it does so.
+/// the homeserver, asserting the caller's identity and the request's
+/// `room_id` as it does so.
 #[tokio::test]
 async fn test_process_delegate_delayed_leave_cs_looks_up_missing_delay_timeout() {
-    /// (CS API URL, delay ID, as_token, user_id) of the recorded lookup.
-    type Lookup = (String, String, String, String);
+    /// (CS API URL, delay ID, room ID, as_token, user_id) of the recorded lookup.
+    type Lookup = (String, String, String, String, String);
     let looked_up: Arc<Mutex<Option<Lookup>>> = Arc::new(Mutex::new(None));
     let looked_up_clone = looked_up.clone();
     let deps = HandlerTestDeps {
@@ -4051,10 +4059,11 @@ async fn test_process_delegate_delayed_leave_cs_looks_up_missing_delay_timeout()
         })),
         participant_exists_fn: participant_exists_block_until_cancelled(),
         get_delayed_event_delay_fn: Some(Box::new(
-            move |cs_api_url, delay_id, as_token, user_id| {
+            move |cs_api_url, delay_id, room_id, as_token, user_id| {
                 *looked_up_clone.lock().unwrap() = Some((
                     cs_api_url.0.clone(),
                     delay_id.to_owned(),
+                    room_id.to_owned(),
                     as_token.to_owned(),
                     user_id.to_owned(),
                 ));
@@ -4072,13 +4081,14 @@ async fn test_process_delegate_delayed_leave_cs_looks_up_missing_delay_timeout()
         .await
         .expect("unexpected error");
 
-    let (cs_api_url, delay_id, as_token, user_id) = looked_up
+    let (cs_api_url, delay_id, room_id, as_token, user_id) = looked_up
         .lock()
         .unwrap()
         .clone()
         .expect("expected the delay to be looked up");
     assert_eq!(cs_api_url, "https://matrix-client.example.com");
     assert_eq!(delay_id, req.delay_id, "expected the requested delay_id");
+    assert_eq!(room_id, req.room_id, "expected the requested room_id");
     assert_eq!(as_token, "as_token", "expected the configured as_token");
     assert_eq!(
         user_id, DELEGATE_DELAYED_LEAVE_CS_MXID,
@@ -4101,7 +4111,7 @@ async fn test_process_delegate_delayed_leave_cs_looked_up_delay_drives_the_job()
         // Confirmed absent, so the job stays in WaitingForInitialConnect until
         // its timeout — which is the looked-up delay — elapses.
         participant_exists_fn: Some(Box::new(|_, _| Box::pin(async { Ok(false) }))),
-        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _| Ok(Duration::from_millis(200)))),
+        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _, _| Ok(Duration::from_millis(200)))),
         execute_delayed_event_action_fn: Some(Box::new(move |_, _, action, _, _| {
             if action == DelayEventAction::Send {
                 *sent_clone.lock().unwrap() = true;
@@ -4138,7 +4148,7 @@ async fn test_process_delegate_delayed_leave_cs_skips_lookup_when_delay_timeout_
             Ok(CsApiUrl("https://matrix-client.example.com".into()))
         })),
         participant_exists_fn: participant_exists_block_until_cancelled(),
-        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _| {
+        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _, _| {
             panic!("the delay must not be looked up when the request carries one")
         })),
         ..Default::default()
@@ -4154,14 +4164,14 @@ async fn test_process_delegate_delayed_leave_cs_skips_lookup_when_delay_timeout_
     handler.close().await;
 }
 
-/// An unknown delay_id surfaces as 404 M_NOT_FOUND.
+/// An unknown delay_id is rejected as HTTP 400 / M_INVALID_PARAM.
 #[tokio::test]
 async fn test_process_delegate_delayed_leave_cs_delay_lookup_not_found() {
     let deps = HandlerTestDeps {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix-client.example.com".into()))
         })),
-        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _| {
+        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _, _| {
             Err(ActionError::DelayedEventNotFound { status: 404 })
         })),
         ..Default::default()
@@ -4174,8 +4184,8 @@ async fn test_process_delegate_delayed_leave_cs_delay_lookup_not_found() {
         .process_delegate_delayed_leave_cs(&req, DELEGATE_DELAYED_LEAVE_CS_MXID)
         .await
         .expect_err("expected MatrixErrorResponse");
-    assert_eq!(err.status, 404, "expected 404");
-    assert_eq!(err.errcode, "M_NOT_FOUND", "expected M_NOT_FOUND");
+    assert_eq!(err.status, 400, "expected 400");
+    assert_eq!(err.errcode, "M_INVALID_PARAM", "expected M_INVALID_PARAM");
     handler.close().await;
 }
 
@@ -4187,7 +4197,7 @@ async fn test_process_delegate_delayed_leave_cs_delay_lookup_unavailable() {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix-client.example.com".into()))
         })),
-        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _| {
+        get_delayed_event_delay_fn: Some(Box::new(|_, _, _, _, _| {
             Err(ActionError::Transient {
                 status: 500,
                 msg: "boom".into(),

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -719,17 +719,19 @@ pub trait Deps: Send + Sync {
         }
     }
 
-    /// GETs the delay of the delayed event identified by `delay_id` from the C-S API.
+    /// GETs the delay of the delayed event identified by `delay_id` from the C-S API,
+    /// verifying it was scheduled for `room_id`.
     ///
-    ///   - 200 with a usable delay → `Ok(delay)`
-    ///   - 404, or 200 with a missing/non-positive delay
-    ///                            → permanent [`ActionError::DelayedEventNotFound`]
+    ///   - 200 for `room_id` with a usable delay → `Ok(delay)`
+    ///   - 404, or 200 for a different room, or 200 with a missing/non-positive
+    ///     delay → permanent [`ActionError::DelayedEventNotFound`]
     ///   - 429 with a usable retry hint → [`ActionError::RetryAfter`]
-    ///   - anything else                → [`ActionError::Transient`]
+    ///   - anything else → [`ActionError::Transient`]
     async fn get_delayed_event_delay(
         &self,
         cs_api_url: &CsApiUrl,
         delay_id: &str,
+        room_id: &str,
         identity: AppServiceIdentity<'_>,
     ) -> Result<Duration, ActionError> {
         let mut endpoint =
@@ -781,12 +783,19 @@ pub trait Deps: Send + Sync {
                     /// emitted by homeservers implementing those.
                     #[serde(default)]
                     delay: i64,
+                    #[serde(default)]
+                    room_id: String,
                 }
                 let parsed: DelayedEventResponse =
                     resp.json().await.map_err(|e| ActionError::Transient {
                         status,
                         msg: format!("failed to parse delayed event response: {e}"),
                     })?;
+                if parsed.room_id != room_id {
+                    // Belongs to a different room than the one being
+                    // delegated for — treated the same as not found.
+                    return Err(ActionError::DelayedEventNotFound { status });
+                }
                 let delay_ms = if parsed.delay_ms > 0 {
                     parsed.delay_ms
                 } else {
@@ -1693,11 +1702,12 @@ mod tests {
 
     // ── get_delayed_event_delay ───────────────────────────────────────────
 
-    async fn get_delay(url: &str, delay_id: &str) -> Result<Duration, ActionError> {
+    async fn get_delay(url: &str, delay_id: &str, room_id: &str) -> Result<Duration, ActionError> {
         RealDeps::default()
             .get_delayed_event_delay(
                 &CsApiUrl(url.to_owned()),
                 delay_id,
+                room_id,
                 AppServiceIdentity {
                     as_token: "as_token",
                     user_id: "@user:example.com",
@@ -1732,13 +1742,15 @@ mod tests {
                             .unwrap_or_default()
                             .to_owned(),
                     );
-                    axum::Json(serde_json::json!({"delay_ms": 30000}))
+                    axum::Json(
+                        serde_json::json!({"delay_ms": 30000, "room_id": "!room:example.com"}),
+                    )
                 }
             }),
         );
         let server = spawn_http_server(router).await;
 
-        let delay = get_delay(&server.url, "delay id/1")
+        let delay = get_delay(&server.url, "delay id/1", "!room:example.com")
             .await
             .expect("unexpected error");
         assert_eq!(delay, Duration::from_secs(30));
@@ -1759,11 +1771,13 @@ mod tests {
     async fn test_get_delayed_event_delay_legacy_field() {
         let router = Router::new().route(
             "/{*path}",
-            any(|| async { axum::Json(serde_json::json!({"delay": 15000})) }),
+            any(|| async {
+                axum::Json(serde_json::json!({"delay": 15000, "room_id": "!room:example.com"}))
+            }),
         );
         let server = spawn_http_server(router).await;
 
-        let delay = get_delay(&server.url, "id")
+        let delay = get_delay(&server.url, "id", "!room:example.com")
             .await
             .expect("unexpected error");
         assert_eq!(delay, Duration::from_secs(15));
@@ -1792,12 +1806,12 @@ mod tests {
             Case {
                 name: "200 with a zero delay",
                 status: http::StatusCode::OK,
-                body: serde_json::json!({"delay_ms": 0}),
+                body: serde_json::json!({"delay_ms": 0, "room_id": "!room:example.com"}),
             },
             Case {
                 name: "200 with a negative delay",
                 status: http::StatusCode::OK,
-                body: serde_json::json!({"delay_ms": -1}),
+                body: serde_json::json!({"delay_ms": -1, "room_id": "!room:example.com"}),
             },
         ] {
             let status = tc.status;
@@ -1811,7 +1825,7 @@ mod tests {
             );
             let server = spawn_http_server(router).await;
 
-            let err = get_delay(&server.url, "id")
+            let err = get_delay(&server.url, "id", "!room:example.com")
                 .await
                 .expect_err(&format!("{}: expected an error", tc.name));
             assert!(
@@ -1820,6 +1834,28 @@ mod tests {
                 tc.name
             );
         }
+    }
+
+    /// A delayed event that exists but was scheduled for a different room
+    /// than the one being delegated for must be rejected the same way as
+    /// an unknown `delay_id`.
+    #[tokio::test]
+    async fn test_get_delayed_event_delay_wrong_room() {
+        let router = Router::new().route(
+            "/{*path}",
+            any(|| async {
+                axum::Json(serde_json::json!({"delay_ms": 30000, "room_id": "!other:example.com"}))
+            }),
+        );
+        let server = spawn_http_server(router).await;
+
+        let err = get_delay(&server.url, "id", "!room:example.com")
+            .await
+            .expect_err("expected an error for a room_id mismatch");
+        assert!(
+            err.is_delayed_event_not_found(),
+            "expected DelayedEventNotFound, got {err:?}"
+        );
     }
 
     /// A rate-limited lookup surfaces its retry hint, so callers can classify it as
@@ -1838,7 +1874,7 @@ mod tests {
         );
         let server = spawn_http_server(router).await;
 
-        let err = get_delay(&server.url, "id")
+        let err = get_delay(&server.url, "id", "!room:example.com")
             .await
             .expect_err("expected an error for 429");
         match err {
@@ -1880,7 +1916,7 @@ mod tests {
                 Router::new().route("/{*path}", any(move || async move { (status, body) }));
             let server = spawn_http_server(router).await;
 
-            let err = get_delay(&server.url, "id")
+            let err = get_delay(&server.url, "id", "!room:example.com")
                 .await
                 .expect_err(&format!("{}: expected an error", tc.name));
             assert!(


### PR DESCRIPTION
This updates the error codes returned from the delegation endpoint to the latest MSC state.