### PR TITLE
Check the user rather than the server room membership in the SS /get_token endpoint

### DIFF
--- a/integration-tests/src/fake_homeserver.rs
+++ b/integration-tests/src/fake_homeserver.rs
@@ -20,7 +20,6 @@ pub struct IsJoinedRequest {
     pub authorization: String,
     pub room_id: String,
     pub mxid: String,
-    pub server_name: String,
 }
 
 /// A request to the MSC4512 /fed_proxy endpoint.
@@ -408,22 +407,15 @@ async fn handle_is_joined(
         .unwrap_or_default()
         .to_owned();
     let mxid = query.get("mxid").cloned().unwrap_or_default();
-    let server_name = query.get("server_name").cloned().unwrap_or_default();
-    let subject = if !mxid.is_empty() {
-        mxid.clone()
-    } else {
-        server_name.clone()
-    };
 
     let mut state = state.lock().unwrap();
     state.is_joined_requests.push(IsJoinedRequest {
         authorization,
         room_id: room_id.clone(),
-        mxid,
-        server_name,
+        mxid: mxid.clone(),
     });
 
-    let joined = !state.not_joined.contains(&(room_id, subject));
+    let joined = !state.not_joined.contains(&(room_id, mxid));
     Json(json!({ "joined": joined }))
 }
 

--- a/integration-tests/src/helpers.rs
+++ b/integration-tests/src/helpers.rs
@@ -243,24 +243,6 @@ pub fn expect_no_is_joined_request(hs: &FakeHomeserver, room_id: &str, mxid: &st
     );
 }
 
-/// Assert that an /is_joined request for the given room and server name has been
-/// recorded with the given `as_token` as its authorization.
-#[track_caller]
-pub fn expect_server_is_joined_request(
-    hs: &FakeHomeserver,
-    room_id: &str,
-    server_name: &str,
-    as_token: &str,
-) {
-    let requests = hs.is_joined_requests();
-    assert!(
-        requests.iter().any(|r| r.room_id == room_id
-            && r.server_name == server_name
-            && r.authorization == format!("Bearer {as_token}")),
-        "expected an is_joined request for room {room_id:?}, server_name {server_name:?}, as_token {as_token:?}, got {requests:?}"
-    );
-}
-
 /// Assert that no fed_proxy request has been recorded.
 #[track_caller]
 pub fn expect_no_fed_proxy_requests(hs: &FakeHomeserver) {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -22,7 +22,7 @@ pub use helpers::{
     expect_job_not_persisted, expect_job_persisted, expect_matrix_error,
     expect_no_delayed_event_request, expect_no_delayed_event_requests,
     expect_no_fed_proxy_requests, expect_no_is_joined_request, expect_no_is_joined_requests,
-    expect_no_user_info_lookups, expect_server_is_joined_request, expect_user_info_lookup,
-    livekit_identity, livekit_room_alias, send_sfu_webhook, wait_for_delayed_event_request,
-    wait_for_delayed_event_request_count, wait_for_job_removed,
+    expect_no_user_info_lookups, expect_user_info_lookup, livekit_identity, livekit_room_alias,
+    send_sfu_webhook, wait_for_delayed_event_request, wait_for_delayed_event_request_count,
+    wait_for_job_removed,
 };

--- a/integration-tests/tests/get_token_ss.rs
+++ b/integration-tests/tests/get_token_ss.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use lk_jwt_service_integration_tests::{
     DEFAULT_LK_URL, FakeHomeserver, FakeSfu, Service, ServiceConfig, decode_livekit_jwt,
-    expect_matrix_error, expect_server_is_joined_request,
+    expect_is_joined_request, expect_matrix_error,
 };
 use serde_json::{Value, json};
 
@@ -189,9 +189,8 @@ async fn get_instead_of_post() {
     assert_eq!(resp.status().as_u16(), 405);
 }
 
-/// A valid request from a joined origin server, for a room our own server
-/// is also joined to, succeeds, both memberships are verified, and the
-/// LiveKit room is created.
+/// A valid request from a joined user of the origin server succeeds, the
+/// user's membership is verified, and the LiveKit room is created.
 #[tokio::test]
 async fn success() {
     let hs = FakeHomeserver::new().await;
@@ -224,8 +223,12 @@ async fn success() {
     assert_eq!(claims["video"]["canPublish"].as_bool(), Some(false));
     assert_eq!(claims["video"]["canSubscribe"].as_bool(), Some(true));
 
-    expect_server_is_joined_request(&hs, "!room:example.com", hs.server_name(), AS_TOKEN);
-    expect_server_is_joined_request(&hs, "!room:example.com", ORIGIN_SERVER, AS_TOKEN);
+    expect_is_joined_request(
+        &hs,
+        "!room:example.com",
+        "@alice:origin.example.org",
+        AS_TOKEN,
+    );
 
     let rooms = sfu.create_room_requests();
     assert_eq!(rooms.len(), 1, "expected exactly one room creation");
@@ -235,11 +238,11 @@ async fn success() {
     );
 }
 
-/// A request is rejected when our own server is not joined to the room.
+/// A request is rejected when the requesting user is not joined to the room.
 #[tokio::test]
-async fn own_server_not_a_member() {
+async fn user_not_a_member() {
     let hs = FakeHomeserver::new().await;
-    hs.set_not_joined("!room:example.com", hs.server_name());
+    hs.set_not_joined("!room:example.com", "@alice:origin.example.org");
 
     let svc = Service::start(ServiceConfig {
         full_access_homeservers: vec!["*".to_owned()],
@@ -260,11 +263,11 @@ async fn own_server_not_a_member() {
     expect_matrix_error(status, &body, 403, "M_FORBIDDEN");
 }
 
-/// A request is rejected when the origin server is not joined to the room.
+/// A request is rejected when `user_id` doesn't belong to the origin
+/// server, without ever checking room membership.
 #[tokio::test]
-async fn origin_server_not_a_member() {
+async fn user_id_domain_mismatch() {
     let hs = FakeHomeserver::new().await;
-    hs.set_not_joined("!room:example.com", ORIGIN_SERVER);
 
     let svc = Service::start(ServiceConfig {
         full_access_homeservers: vec!["*".to_owned()],
@@ -276,7 +279,7 @@ async fn origin_server_not_a_member() {
 
     let (status, body) = post_get_token_ss(
         &svc,
-        get_token_ss_request("@alice:origin.example.org", DEFAULT_LK_URL).to_string(),
+        get_token_ss_request("@alice:not-the-origin.example.org", DEFAULT_LK_URL).to_string(),
         Some(ORIGIN_SERVER),
         Some(HS_TOKEN),
     )

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1098,51 +1098,47 @@ impl Handler {
     ) -> Result<GetTokenSsResponse, MatrixErrorResponse> {
         require_non_empty_header(origin_header, "Missing request origin")?;
 
+        let user_server_name =
+            matrix_server_name(&req.user_id).ok_or_else(|| MatrixErrorResponse {
+                status: 400,
+                errcode: "M_INVALID_PARAM".into(),
+                err: "Malformed user identifier".into(),
+            })?;
+        if user_server_name != origin_header {
+            return Err(MatrixErrorResponse {
+                status: 403,
+                errcode: "M_FORBIDDEN".into(),
+                err: "The user_id does not belong to the origin server".into(),
+            });
+        }
+
         let cs_api_url = self
             .resolve_cs_api_url_or_bad_request(&self.app_service_config.hs_server_name)
             .await?;
 
-        let membership_error = || MatrixErrorResponse {
-            status: 502,
-            errcode: "M_UNKNOWN".into(),
-            err: "Unable to verify room membership".into(),
-        };
-
-        let own_is_member = self
+        let is_member = self
             .deps
-            .is_server_joined(
+            .is_user_joined(
                 &cs_api_url,
                 &req.room_id,
-                &self.app_service_config.hs_server_name,
+                &req.user_id,
                 &self.app_service_config.as_token,
             )
             .await
             .map_err(|err| {
-                error!(room = %req.room_id, err = %err,
-                    "Handler: error checking own server's room membership (app-service S-S)");
-                membership_error()
+                error!(user_id = %req.user_id, room = %req.room_id, err = %err,
+                    "Handler: error checking room membership (app-service S-S)");
+                MatrixErrorResponse {
+                    status: 502,
+                    errcode: "M_UNKNOWN".into(),
+                    err: "Unable to verify room membership".into(),
+                }
             })?;
-
-        let origin_is_member = self
-            .deps
-            .is_server_joined(
-                &cs_api_url,
-                &req.room_id,
-                origin_header,
-                &self.app_service_config.as_token,
-            )
-            .await
-            .map_err(|err| {
-                error!(room = %req.room_id, origin = %origin_header, err = %err,
-                    "Handler: error checking origin server's room membership (app-service S-S)");
-                membership_error()
-            })?;
-
-        if !own_is_member || !origin_is_member {
+        if !is_member {
             return Err(MatrixErrorResponse {
                 status: 403,
                 errcode: "M_FORBIDDEN".into(),
-                err: "The receiving or requesting server is not a member of the room".into(),
+                err: "The requesting user is not a member of the room".into(),
             });
         }
 

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -59,7 +59,6 @@ struct HandlerTestDeps {
     execute_delayed_event_action_fn: Option<ExecuteDelayedEventActionFn>,
     get_delayed_event_delay_fn: Option<GetDelayedEventDelayFn>,
     is_user_joined_fn: Option<IsJoinedFn>,
-    is_server_joined_fn: Option<IsJoinedFn>,
     request_get_token_via_federation_fn: Option<RequestGetTokenViaFederationFn>,
 }
 
@@ -168,19 +167,6 @@ impl Deps for HandlerTestDeps {
         match &self.is_user_joined_fn {
             Some(f) => f(cs_api_url, room_id, mxid),
             None => panic!("is_user_joined not mocked in HandlerTestDeps"),
-        }
-    }
-
-    async fn is_server_joined(
-        &self,
-        cs_api_url: &CsApiUrl,
-        room_id: &str,
-        server_name: &str,
-        _as_token: &str,
-    ) -> Result<bool, String> {
-        match &self.is_server_joined_fn {
-            Some(f) => f(cs_api_url, room_id, server_name),
-            None => panic!("is_server_joined not mocked in HandlerTestDeps"),
         }
     }
 
@@ -3013,7 +2999,7 @@ async fn test_handle_get_token_ss_url_mismatch() {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
-        is_server_joined_fn: Some(Box::new(|_, _, _| Ok(true))),
+        is_user_joined_fn: is_joined_ok(true),
         ..Default::default()
     };
     let handler = new_get_token_ss_handler(deps);
@@ -3042,7 +3028,7 @@ async fn test_handle_get_token_ss_success() {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
-        is_server_joined_fn: Some(Box::new(|_, _, _| Ok(true))),
+        is_user_joined_fn: is_joined_ok(true),
         create_livekit_room_fn: Some(Box::new(move |_, _, _| {
             create_called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
             Ok(())
@@ -3069,20 +3055,20 @@ async fn test_handle_get_token_ss_success() {
     handler.close().await;
 }
 
-/// If our own server isn't a member of the room, the request is rejected.
+/// If `user_id` does not belong to the origin server, the request is
+/// rejected without even checking room membership.
 #[tokio::test]
-async fn test_handle_get_token_ss_own_server_not_a_member() {
+async fn test_handle_get_token_ss_user_id_domain_mismatch() {
     let deps = HandlerTestDeps {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
-        is_server_joined_fn: Some(Box::new(|_, _, server_name| {
-            Ok(server_name != "example.com")
-        })),
         ..Default::default()
     };
     let handler = new_get_token_ss_handler(deps);
-    let body = marshal_get_token_ss_request(|_| {});
+    let body = marshal_get_token_ss_request(|r| {
+        r.user_id = "@user:not-the-origin.example.org".into();
+    });
     let resp = send_request(
         &handler,
         post_get_token_ss_request(body, GET_TOKEN_SS_ORIGIN),
@@ -3091,22 +3077,20 @@ async fn test_handle_get_token_ss_own_server_not_a_member() {
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "expected 403 when our own server isn't a member"
+        "expected 403 when user_id doesn't belong to the origin server"
     );
     handler.close().await;
 }
 
-/// If the origin server isn't a member of the room, the request is
+/// If the requesting user isn't a member of the room, the request is
 /// rejected.
 #[tokio::test]
-async fn test_handle_get_token_ss_origin_server_not_a_member() {
+async fn test_handle_get_token_ss_user_not_a_member() {
     let deps = HandlerTestDeps {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
-        is_server_joined_fn: Some(Box::new(|_, _, server_name| {
-            Ok(server_name == "example.com")
-        })),
+        is_user_joined_fn: is_joined_ok(false),
         ..Default::default()
     };
     let handler = new_get_token_ss_handler(deps);
@@ -3119,7 +3103,7 @@ async fn test_handle_get_token_ss_origin_server_not_a_member() {
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
-        "expected 403 when the origin server isn't a member"
+        "expected 403 when the requesting user isn't a member"
     );
     handler.close().await;
 }
@@ -3131,7 +3115,7 @@ async fn test_handle_get_token_ss_membership_check_error() {
         resolve_cs_api_url_fn: Some(Box::new(|_| {
             Ok(CsApiUrl("https://matrix.example.com".into()))
         })),
-        is_server_joined_fn: Some(Box::new(|_, _, _| Err("boom".into()))),
+        is_user_joined_fn: Some(Box::new(|_, _, _| Err("boom".into()))),
         ..Default::default()
     };
     let handler = new_get_token_ss_handler(deps);
@@ -3182,11 +3166,10 @@ async fn test_process_get_token_ss_request() {
         name: &'static str,
         origin: &'static str,
         url: &'static str,
+        user_id: &'static str,
         fail_resolution: bool,
-        fail_own_membership: bool,
-        fail_origin_membership: bool,
-        own_is_member: bool,
-        origin_is_member: bool,
+        fail_membership: bool,
+        is_member: bool,
         fail_join_token: bool,
         expect_create_room: bool,
         expect_error: bool,
@@ -3195,11 +3178,10 @@ async fn test_process_get_token_ss_request() {
         name: "",
         origin: ORIGIN_SERVER,
         url: LK_URL,
+        user_id: "@user:origin.example.org",
         fail_resolution: false,
-        fail_own_membership: false,
-        fail_origin_membership: false,
-        own_is_member: true,
-        origin_is_member: true,
+        fail_membership: false,
+        is_member: true,
         fail_join_token: false,
         expect_create_room: false,
         expect_error: false,
@@ -3217,26 +3199,20 @@ async fn test_process_get_token_ss_request() {
             ..base
         },
         Case {
-            name: "Own server not a member",
-            own_is_member: false,
+            name: "User id domain mismatch",
+            user_id: "@user:not-the-origin.example.org",
             expect_error: true,
             ..base
         },
         Case {
-            name: "Origin server not a member",
-            origin_is_member: false,
+            name: "User not a member",
+            is_member: false,
             expect_error: true,
             ..base
         },
         Case {
-            name: "Own membership check transport error",
-            fail_own_membership: true,
-            expect_error: true,
-            ..base
-        },
-        Case {
-            name: "Origin membership check transport error",
-            fail_origin_membership: true,
+            name: "Membership check transport error",
+            fail_membership: true,
             expect_error: true,
             ..base
         },
@@ -3254,10 +3230,8 @@ async fn test_process_get_token_ss_request() {
         },
     ] {
         let fail_resolution = tc.fail_resolution;
-        let fail_own_membership = tc.fail_own_membership;
-        let fail_origin_membership = tc.fail_origin_membership;
-        let own_is_member = tc.own_is_member;
-        let origin_is_member = tc.origin_is_member;
+        let fail_membership = tc.fail_membership;
+        let is_member = tc.is_member;
 
         let create_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let create_called_clone = create_called.clone();
@@ -3270,17 +3244,11 @@ async fn test_process_get_token_ss_request() {
                     Ok(CsApiUrl("https://matrix.example.com".into()))
                 }
             })),
-            is_server_joined_fn: Some(Box::new(move |_, _, server_name| {
-                if server_name == OWN_SERVER {
-                    if fail_own_membership {
-                        Err("boom".into())
-                    } else {
-                        Ok(own_is_member)
-                    }
-                } else if fail_origin_membership {
+            is_user_joined_fn: Some(Box::new(move |_, _, _| {
+                if fail_membership {
                     Err("boom".into())
                 } else {
-                    Ok(origin_is_member)
+                    Ok(is_member)
                 }
             })),
             create_livekit_room_fn: Some(Box::new(move |_, _, _| {
@@ -3315,7 +3283,7 @@ async fn test_process_get_token_ss_request() {
 
         let req = GetTokenSsRequest {
             url: tc.url.into(),
-            user_id: "@user:origin.example.org".into(),
+            user_id: tc.user_id.into(),
             room_id: "!room:example.com".into(),
             slot_id: "slot".into(),
             member: MatrixRtcMemberType {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -518,23 +518,6 @@ async fn retry_after_from_response(resp: reqwest::Response, status: u16) -> Acti
     }
 }
 
-/// The subject of an `/is_joined` query (MSC4502): either a specific Matrix
-/// user ID or a server name.
-pub enum IsJoinedSubject<'a> {
-    Mxid(&'a str),
-    ServerName(&'a str),
-}
-
-impl IsJoinedSubject<'_> {
-    /// The `(query parameter name, value)` pair to send for this subject.
-    fn query(&self) -> (&'static str, &str) {
-        match self {
-            IsJoinedSubject::Mxid(mxid) => ("mxid", mxid),
-            IsJoinedSubject::ServerName(server_name) => ("server_name", server_name),
-        }
-    }
-}
-
 /// The outcome of a failed `/get_token` federation relay: either the
 /// destination homeserver rejected the request (`status` and `errcode` as
 /// reported by it), or something else went wrong reaching it.
@@ -942,37 +925,6 @@ pub trait Deps: Send + Sync {
         mxid: &str,
         as_token: &str,
     ) -> Result<bool, String> {
-        self.check_is_joined(cs_api_url, room_id, IsJoinedSubject::Mxid(mxid), as_token)
-            .await
-    }
-
-    /// Checks whether `server_name` is currently joined to `room_id`, via the
-    /// `/is_joined` endpoint from MSC4502.
-    async fn is_server_joined(
-        &self,
-        cs_api_url: &CsApiUrl,
-        room_id: &str,
-        server_name: &str,
-        as_token: &str,
-    ) -> Result<bool, String> {
-        self.check_is_joined(
-            cs_api_url,
-            room_id,
-            IsJoinedSubject::ServerName(server_name),
-            as_token,
-        )
-        .await
-    }
-
-    /// Performs a room membership check for an MXID or server name, via the
-    /// `/is_joined` endpoint from MSC4502.
-    async fn check_is_joined(
-        &self,
-        cs_api_url: &CsApiUrl,
-        room_id: &str,
-        subject: IsJoinedSubject<'_>,
-        as_token: &str,
-    ) -> Result<bool, String> {
         const IS_JOINED_PATH_PREFIX: &str = "_matrix/client/unstable/io.element.msc4502";
 
         let mut endpoint = url::Url::parse(cs_api_url.as_str())
@@ -989,10 +941,7 @@ pub trait Deps: Send + Sync {
             segments.push(room_id);
             segments.push("is_joined");
         }
-        let (query_param, query_value) = subject.query();
-        endpoint
-            .query_pairs_mut()
-            .append_pair(query_param, query_value);
+        endpoint.query_pairs_mut().append_pair("mxid", mxid);
 
         let resp = http_client(self.skip_verify_tls())
             .get(endpoint.clone())
@@ -1002,7 +951,7 @@ pub trait Deps: Send + Sync {
             .await
             .map_err(|e| {
                 let msg = error_chain(&e);
-                debug!(url = %endpoint, err = %msg, "check_is_joined");
+                debug!(url = %endpoint, err = %msg, "is_user_joined");
                 format!("failed to check room membership: {msg}")
             })?;
 
@@ -2457,7 +2406,7 @@ mod tests {
         assert_eq!(captured.user_id, None);
     }
 
-    // ── check_is_joined ──────────────────────────────────────────────────────
+    // ── is_user_joined ───────────────────────────────────────────────────────
 
     /// A homeserver stub serving /is_joined at the unstable MSC4502 path.
     struct IsJoinedServer {
@@ -2487,14 +2436,14 @@ mod tests {
     /// The unstable MSC4502 endpoint is always used, regardless of what the
     /// homeserver advertises.
     #[tokio::test]
-    async fn test_check_is_joined_uses_unstable_endpoint() {
+    async fn test_is_user_joined_uses_unstable_endpoint() {
         let hs = spawn_is_joined_server(true).await;
 
         let joined = RealDeps::default()
-            .check_is_joined(
+            .is_user_joined(
                 &CsApiUrl(hs.server.url.clone()),
                 "!room:example.com",
-                IsJoinedSubject::Mxid("@alice:example.com"),
+                "@alice:example.com",
                 "as_token",
             )
             .await
@@ -2514,14 +2463,14 @@ mod tests {
 
     /// `joined: false` responses propagate as Ok(false), not an error.
     #[tokio::test]
-    async fn test_check_is_joined_not_joined() {
+    async fn test_is_user_joined_not_joined() {
         let hs = spawn_is_joined_server(false).await;
 
         let joined = RealDeps::default()
-            .check_is_joined(
+            .is_user_joined(
                 &CsApiUrl(hs.server.url.clone()),
                 "!room:example.com",
-                IsJoinedSubject::Mxid("@alice:example.com"),
+                "@alice:example.com",
                 "as_token",
             )
             .await
@@ -2531,7 +2480,7 @@ mod tests {
 
     /// A non-2xx response from the is_joined endpoint itself surfaces as an error.
     #[tokio::test]
-    async fn test_check_is_joined_http_error() {
+    async fn test_is_user_joined_http_error() {
         let router = Router::new().route(
             "/_matrix/client/unstable/io.element.msc4502/rooms/{room_id}/is_joined",
             any(|| async { http::StatusCode::FORBIDDEN }),
@@ -2539,18 +2488,16 @@ mod tests {
         let server = spawn_http_server(router).await;
 
         let err = RealDeps::default()
-            .check_is_joined(
+            .is_user_joined(
                 &CsApiUrl(server.url.clone()),
                 "!room:example.com",
-                IsJoinedSubject::Mxid("@alice:example.com"),
+                "@alice:example.com",
                 "as_token",
             )
             .await
             .expect_err("expected an error for a non-2xx is_joined response");
         assert!(err.contains("403"), "unexpected error message: {err}");
     }
-
-    // ── is_user_joined ───────────────────────────────────────────────────────
 
     /// The request is shaped correctly: it uses `mxid`.
     #[tokio::test]
@@ -2577,42 +2524,6 @@ mod tests {
         assert!(
             uri.contains("%21room%3Aexample.com") || uri.contains("!room:example.com"),
             "expected the room ID in the path, got {uri:?}"
-        );
-        assert_eq!(
-            headers
-                .get(http::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok()),
-            Some("Bearer the_as_token"),
-        );
-    }
-
-    // ── is_server_joined ─────────────────────────────────────────────────────
-
-    /// The request is shaped correctly: it uses `server_name`, not `mxid`.
-    #[tokio::test]
-    async fn test_is_server_joined_request_shape() {
-        let hs = spawn_is_joined_server(true).await;
-
-        let _ = RealDeps::default()
-            .is_server_joined(
-                &CsApiUrl(hs.server.url.clone()),
-                "!room:example.com",
-                "origin.example.org",
-                "the_as_token",
-            )
-            .await
-            .expect("unexpected error");
-
-        let requests = hs.requests.lock().unwrap();
-        assert_eq!(requests.len(), 1);
-        let (uri, headers) = &requests[0];
-        assert!(
-            uri.contains("server_name=origin.example.org"),
-            "expected a server_name query param, got {uri:?}"
-        );
-        assert!(
-            !uri.contains("mxid="),
-            "expected no mxid query param, got {uri:?}"
         );
         assert_eq!(
             headers


### PR DESCRIPTION
As per the latest state of the MSC, this changes the `/get_token` federation endpoint to validate the supplied user ID belongs to the origin server and that the user (rather than the server) is joined to the room.