### PR TITLE
Add url parameter on CS delegation request

### DIFF
--- a/e2e-tests/tests/delegate_delayed_leave.rs
+++ b/e2e-tests/tests/delegate_delayed_leave.rs
@@ -227,6 +227,7 @@ async fn delegate_delayed_leave_cs_succeeds() {
         ))
         .bearer_auth(&user.access_token)
         .json(&serde_json::json!({
+            "url": LIVEKIT_A_URL,
             "room_id": room_id,
             "slot_id": SLOT_ID,
             "member": {

--- a/integration-tests/tests/delegate_delayed_leave_cs.rs
+++ b/integration-tests/tests/delegate_delayed_leave_cs.rs
@@ -7,9 +7,10 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use lk_jwt_service_integration_tests::{
-    FakeHomeserver, FakeRedis, Service, ServiceConfig, expect_delayed_event_request_identity,
-    expect_job_persisted, expect_matrix_error, expect_no_delayed_event_requests, livekit_identity,
-    livekit_room_alias, send_sfu_webhook, wait_for_delayed_event_request, wait_for_job_removed,
+    DEFAULT_LK_URL, FakeHomeserver, FakeRedis, Service, ServiceConfig,
+    expect_delayed_event_request_identity, expect_job_persisted, expect_matrix_error,
+    expect_no_delayed_event_requests, livekit_identity, livekit_room_alias, send_sfu_webhook,
+    wait_for_delayed_event_request, wait_for_job_removed,
 };
 use serde_json::{Value, json};
 
@@ -32,8 +33,9 @@ fn app_service_env_with_hs_server_name(hs_server_name: &str) -> HashMap<String, 
 }
 
 /// Return a valid delegate_delayed_leave C-S request body.
-fn delegate_request() -> Value {
+fn delegate_request(lk_url: &str) -> Value {
     json!({
+        "url": lk_url,
         "room_id": "!room:example.com",
         "slot_id": "m.call#",
         "member": {
@@ -93,7 +95,7 @@ async fn missing_hs_token() {
 
     let (status, body) = post_delegate_cs_as(
         &svc,
-        delegate_request().to_string(),
+        delegate_request(DEFAULT_LK_URL).to_string(),
         Some("@alice:example.com"),
         None,
     )
@@ -117,7 +119,7 @@ async fn wrong_hs_token() {
 
     let (status, body) = post_delegate_cs_as(
         &svc,
-        delegate_request().to_string(),
+        delegate_request(DEFAULT_LK_URL).to_string(),
         Some("@alice:example.com"),
         Some("not_the_hs_token"),
     )
@@ -139,9 +141,54 @@ async fn missing_header() {
     })
     .await;
 
-    let (status, body) = post_delegate_cs(&svc, delegate_request().to_string(), None).await;
+    let (status, body) =
+        post_delegate_cs(&svc, delegate_request(DEFAULT_LK_URL).to_string(), None).await;
 
     expect_matrix_error(status, &body, 401, "M_UNAUTHORIZED");
+    expect_no_delayed_event_requests(&hs);
+}
+
+/// A url not matching the service's configured LIVEKIT_URL is rejected.
+#[tokio::test]
+async fn url_mismatch() {
+    let hs = FakeHomeserver::new().await;
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let (status, body) = post_delegate_cs(
+        &svc,
+        delegate_request("wss://not-the-configured-sfu.example.com").to_string(),
+        Some("@alice:example.com"),
+    )
+    .await;
+
+    expect_matrix_error(status, &body, 400, "M_INVALID_PARAM");
+    expect_no_delayed_event_requests(&hs);
+}
+
+/// A missing url is rejected.
+#[tokio::test]
+async fn missing_url() {
+    let hs = FakeHomeserver::new().await;
+
+    let svc = Service::start(ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        extra_env: app_service_env_with_hs_server_name(hs.server_name()),
+        ..Default::default()
+    })
+    .await;
+
+    let mut request = delegate_request(DEFAULT_LK_URL);
+    request["url"] = json!("");
+    let (status, body) =
+        post_delegate_cs(&svc, request.to_string(), Some("@alice:example.com")).await;
+
+    expect_matrix_error(status, &body, 400, "M_BAD_JSON");
     expect_no_delayed_event_requests(&hs);
 }
 
@@ -157,7 +204,7 @@ async fn missing_fields() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_id");
     let (status, body) =
         post_delegate_cs(&svc, request.to_string(), Some("@alice:example.com")).await;
@@ -223,7 +270,7 @@ async fn unresolvable_cs_api() {
 
     let (status, body) = post_delegate_cs(
         &svc,
-        delegate_request().to_string(),
+        delegate_request(DEFAULT_LK_URL).to_string(),
         Some("@alice:example.com"),
     )
     .await;
@@ -246,8 +293,12 @@ async fn success() {
     })
     .await;
 
-    let (status, body) =
-        post_delegate_cs(&svc, delegate_request().to_string(), Some(&user.user_id)).await;
+    let (status, body) = post_delegate_cs(
+        &svc,
+        delegate_request(DEFAULT_LK_URL).to_string(),
+        Some(&user.user_id),
+    )
+    .await;
 
     assert_eq!(status, 200, "body: {body}");
     let response: Value = serde_json::from_str(&body).expect("response is not JSON");
@@ -278,8 +329,12 @@ async fn restart_and_send_use_identity_assertion() {
     })
     .await;
 
-    let (status, body) =
-        post_delegate_cs(&svc, delegate_request().to_string(), Some(&user.user_id)).await;
+    let (status, body) = post_delegate_cs(
+        &svc,
+        delegate_request(DEFAULT_LK_URL).to_string(),
+        Some(&user.user_id),
+    )
+    .await;
     assert_eq!(status, 200, "body: {body}");
 
     // The job should be persisted.
@@ -343,7 +398,7 @@ async fn delay_timeout_looked_up_when_absent() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
     assert_eq!(status, 200, "body: {body}");
@@ -386,8 +441,12 @@ async fn delay_timeout_not_looked_up_when_given() {
     })
     .await;
 
-    let (status, body) =
-        post_delegate_cs(&svc, delegate_request().to_string(), Some(&user.user_id)).await;
+    let (status, body) = post_delegate_cs(
+        &svc,
+        delegate_request(DEFAULT_LK_URL).to_string(),
+        Some(&user.user_id),
+    )
+    .await;
     assert_eq!(status, 200, "body: {body}");
 
     let lookups = hs.delay_lookups();
@@ -411,7 +470,7 @@ async fn looked_up_delay_drives_the_job() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
     assert_eq!(status, 200, "body: {body}");
@@ -436,7 +495,7 @@ async fn unknown_delay_id_rejected() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
 
@@ -460,7 +519,7 @@ async fn delay_id_for_another_room_rejected() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
 
@@ -485,7 +544,7 @@ async fn delay_lookup_failure_rejected() {
     })
     .await;
 
-    let mut request = delegate_request();
+    let mut request = delegate_request(DEFAULT_LK_URL);
     request.as_object_mut().unwrap().remove("delay_timeout");
     let (status, body) = post_delegate_cs(&svc, request.to_string(), Some(&user.user_id)).await;
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1229,6 +1229,8 @@ impl Handler {
     ) -> Result<DelegateDelayedLeaveResponse, MatrixErrorResponse> {
         require_non_empty_header(mxid_header, "Missing request authorization")?;
 
+        self.require_matching_lk_url(&req.url, "delegate_delayed_leave_cs")?;
+
         let lk_identity =
             livekit_identity_for(mxid_header, &req.member.claimed_device_id, &req.member.id);
         let lk_room_alias = livekit_room_alias_for(&req.room_id, &req.slot_id);

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -511,6 +511,7 @@ const DELEGATE_DELAYED_LEAVE_CS_MXID: &str = "@user:example.com";
 /// A fully populated, valid delegate_delayed_leave C-S request.
 fn valid_delegate_delayed_leave_cs_request() -> DelegateDelayedLeaveCsRequest {
     DelegateDelayedLeaveCsRequest {
+        url: default_auth().lk_url,
         room_id: "!testRoom:example.com".into(),
         slot_id: "m.call#ROOM".into(),
         member: MatrixRtcMemberType {
@@ -4016,6 +4017,48 @@ async fn test_handle_delegate_delayed_leave_cs_missing_fields() {
     handler.close().await;
 }
 
+/// A missing `url` is rejected by DelegateDelayedLeaveCsRequest::validate()
+/// with 400 M_BAD_JSON, before the handler is even invoked.
+#[tokio::test]
+async fn test_handle_delegate_delayed_leave_cs_missing_url() {
+    let handler = new_delegate_delayed_leave_cs_handler(HandlerTestDeps::default());
+    let body = marshal_delegate_delayed_leave_cs_request(|r| {
+        r.url = String::new();
+    });
+    let resp = send_request(
+        &handler,
+        post_delegate_delayed_leave_cs_request(body, DELEGATE_DELAYED_LEAVE_CS_MXID),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "expected 400 for a missing `url`"
+    );
+    handler.close().await;
+}
+
+/// A `url` that doesn't match the configured LiveKit URL is rejected with
+/// 400 M_INVALID_PARAM.
+#[tokio::test]
+async fn test_handle_delegate_delayed_leave_cs_url_mismatch() {
+    let handler = new_delegate_delayed_leave_cs_handler(HandlerTestDeps::default());
+    let body = marshal_delegate_delayed_leave_cs_request(|r| {
+        r.url = "wss://not-the-configured-sfu.example.com".into();
+    });
+    let resp = send_request(
+        &handler,
+        post_delegate_delayed_leave_cs_request(body, DELEGATE_DELAYED_LEAVE_CS_MXID),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "expected 400 for a `url` mismatch"
+    );
+    handler.close().await;
+}
+
 /// A CS-API URL resolution failure surfaces as 400.
 #[tokio::test]
 async fn test_handle_delegate_delayed_leave_cs_cs_api_url_resolution_error() {
@@ -4082,6 +4125,23 @@ async fn test_process_delegate_delayed_leave_cs_missing_mxid() {
         .expect_err("expected MatrixErrorResponse");
     assert_eq!(err.status, 401, "expected 401");
     assert_eq!(err.errcode, "M_UNAUTHORIZED", "expected M_UNAUTHORIZED");
+    handler.close().await;
+}
+
+/// A `url` that doesn't match the configured LiveKit URL is rejected with
+/// 400 M_INVALID_PARAM, before any homeserver calls are made.
+#[tokio::test]
+async fn test_process_delegate_delayed_leave_cs_url_mismatch() {
+    let handler = new_delegate_delayed_leave_cs_handler(HandlerTestDeps::default());
+    let mut req = valid_delegate_delayed_leave_cs_request();
+    req.url = "wss://not-the-configured-sfu.example.com".into();
+
+    let err = handler
+        .process_delegate_delayed_leave_cs(&req, DELEGATE_DELAYED_LEAVE_CS_MXID)
+        .await
+        .expect_err("expected MatrixErrorResponse");
+    assert_eq!(err.status, 400, "expected 400");
+    assert_eq!(err.errcode, "M_INVALID_PARAM", "expected M_INVALID_PARAM");
     handler.close().await;
 }
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -262,6 +262,8 @@ pub struct DelegateDelayedLeaveResponse {}
 #[serde(deny_unknown_fields)]
 pub struct DelegateDelayedLeaveCsRequest {
     #[serde(default)]
+    pub url: String,
+    #[serde(default)]
     pub room_id: String,
     #[serde(default)]
     pub slot_id: String,
@@ -277,11 +279,11 @@ pub struct DelegateDelayedLeaveCsRequest {
 
 impl DelegateDelayedLeaveCsRequest {
     pub fn validate(&self) -> Result<(), MatrixErrorResponse> {
-        if self.room_id.is_empty() || self.slot_id.is_empty() {
+        if self.url.is_empty() || self.room_id.is_empty() || self.slot_id.is_empty() {
             return Err(MatrixErrorResponse {
                 status: 400,
                 errcode: "M_BAD_JSON".into(),
-                err: "The request body is missing `room_id` or `slot_id`".into(),
+                err: "The request body is missing `url`, `room_id` or `slot_id`".into(),
             });
         }
         self.member
@@ -750,6 +752,7 @@ mod tests {
 
     pub(crate) fn valid_delegate_delayed_leave_cs_request() -> DelegateDelayedLeaveCsRequest {
         DelegateDelayedLeaveCsRequest {
+            url: "wss://lk.local".into(),
             room_id: "!testRoom:example.com".into(),
             slot_id: "m.call#ROOM".into(),
             member: MatrixRtcMemberType {
@@ -766,6 +769,13 @@ mod tests {
     fn test_delegate_delayed_leave_cs_request_validate_valid() {
         let req = valid_delegate_delayed_leave_cs_request();
         assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn test_delegate_delayed_leave_cs_request_validate_missing_url() {
+        let mut req = valid_delegate_delayed_leave_cs_request();
+        req.url = String::new();
+        assert_validation_error(req.validate(), "M_BAD_JSON");
     }
 
     #[test]
@@ -842,6 +852,7 @@ mod tests {
     fn test_delegate_delayed_leave_cs_request_deserialize_without_delay_timeout() {
         let req: DelegateDelayedLeaveCsRequest = serde_json::from_str(
             r#"{
+                "url": "wss://lk.local",
                 "room_id": "!testRoom:example.com",
                 "slot_id": "m.call#ROOM",
                 "member": {"id": "member-id", "claimed_device_id": "device-id"},

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use tracing::error;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct MatrixRtcMemberType {
     #[serde(default)]
     pub id: String,
@@ -36,7 +35,6 @@ impl MatrixRtcMemberType {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct OpenIdTokenType {
     #[serde(default)]
     pub access_token: String,
@@ -52,7 +50,6 @@ pub struct OpenIdTokenType {
 /// pre-Matrix-2.0 endpoint. Remove once all in-the-wild clients have
 /// migrated to /get_token (SfuRequest).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct LegacySfuRequest {
     #[serde(default)]
     pub room: String,
@@ -71,7 +68,6 @@ pub struct LegacySfuRequest {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct SfuRequest {
     #[serde(default)]
     pub room_id: String,
@@ -107,7 +103,6 @@ pub struct SfuResponse {
 
 /// Request body of the `/rtc/livekit/get_token` endpoint.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct GetTokenCsRequest {
     #[serde(default)]
     pub server_name: String,
@@ -129,7 +124,6 @@ pub struct GetTokenCsResponse {
 
 /// Request body of the `/rtc/livekit/get_token` S-S endpoint.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct GetTokenSsRequest {
     #[serde(default)]
     pub url: String,
@@ -195,7 +189,6 @@ impl GetTokenSsRequest {
 /// so the participant-lookup task uses its backoff to confirm presence
 /// rather than waiting for the webhook (which has already fired).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct DelegateDelayedLeaveRequest {
     #[serde(default)]
     pub room_id: String,
@@ -259,7 +252,6 @@ pub struct DelegateDelayedLeaveResponse {}
 
 /// The request body of /delegate_delayed_leave.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct DelegateDelayedLeaveCsRequest {
     #[serde(default)]
     pub url: String,
@@ -309,7 +301,6 @@ impl DelegateDelayedLeaveCsRequest {
 
 /// The request body of POST /appservice-ping.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AppservicePingTriggerRequest {
     #[serde(default)]
     pub server_name: String,


### PR DESCRIPTION
This adds a `url` parameter on the CS `/delegate_delayed_leave` request as per the latest MSC state.

While at it, I also removed the `#[serde(deny_unknown_fields)]` directives. If we fail requests with extra keys, upgrading will be a pain in the future.