### PR TITLE
Verify room membership on a cycle and kick left users from the SFU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "prost",
  "rcgen",
  "reqwest 0.13.4",
+ "rustls",
  "serde_json",
  "sha2 0.11.0",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Set environment variables to configure the service:
 | `LIVEKIT_JWT_PORT`                            | ⚠️ Deprecated Port to bind the server to                      | ❌ No, ⚠️ mutually exclusive with `LIVEKIT_JWT_BIND` |         |
 | `LIVEKIT_FULL_ACCESS_HOMESERVERS`             | Comma-separated list of full-access homeservers (`*` for all — see security note below). Ignored when serving C-S and S-S endpoints as an application service. | ✅ Yes                                               |         |
 | `LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS`       | Interval (seconds) at which delegated-leave jobs re-check that a connected participant is still on the SFU. Guards against missed SFU webhooks. Unset/`0` disables the sanity check. | ❌ No                                                | `0` (disabled) |
+| `LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS`   | Interval (seconds) at which SFU participants are checked against Matrix room membership and removed if they left, or were kicked or banned (see [Kicking users from the SFU](#-kicking-users-from-the-sfu-on-room-leaveban)). `0` disables the check. Only effective when running as an application service. | ❌ No                                                | `30` |
 | `LIVEKIT_LOG_LEVEL`                           | One of `debug`, `info`, `warn`/`warning`, `error`             | ❌ No                                                | `info` |
 | `LIVEKIT_CS_API_URL_OVERRIDES`                | Comma-separated list of overrides for Client-Server API locations that cannot be inferred using .well-known discovery (e.g. `example.com=matrix-client.example.com`) | ❌ No                                                | |
 | `LIVEKIT_REDIS_URL`                           | Redis connection URL (e.g. `redis://localhost:6379`). When set, service state will be persisted during operation and restored upon service restarts. When unset, the service falls back to an in-memory store. | ❌ No | |
@@ -135,15 +136,20 @@ When set up as an application service, the integration depends on
 [MSC4502](https://github.com/matrix-org/matrix-spec-proposals/pull/4502) and
 [MSC4512](https://github.com/matrix-org/matrix-spec-proposals/pull/4512).
 
-The service needs to cover all local users because it needs to verify room memberships
-without being joined to any rooms itself. This requires the `urn:matrix:client:rooms:is_joined`
-scope to be set. The service does not require any event traffic, however. So make sure to set
-`url` to `null`.
+The service needs to cover all *local* users of the homeserver: it acts on their behalf when
+managing delegated delayed events and queries room memberships without being joined to any
+rooms itself. The latter requires the `urn:matrix:client:rooms:is_joined` scope to be set.
+The `users` namespace should not extend to remote users though (i.e. don't use `.*`): the
+service relies on the homeserver refusing `/joined_members` once none of the service's users
+is in a room any more, which is how it notices that the homeserver itself has left (see
+[Kicking users from the SFU](#-kicking-users-from-the-sfu-on-room-leaveban)). The service
+does not require any event traffic. So make sure to set `url` to `null`.
 
 Additionally, request proxying needs to be enabled for the `/rtc/livekit` subpath in the Client-Server
 and Server-Server API. This is done via the `proxy_prefix` and `proxy_url` properties.
 
-Below is an example application service registration file.
+Below is an example application service registration file for a homeserver with the server
+name `example.com`.
 
 ```yaml
 id: "LiveKit JWT service"
@@ -153,7 +159,7 @@ sender_localpart: "_lk_jwt_service"
 namespaces:
   users:
     - exclusive: false
-      regex: ".*" # Cover all users
+      regex: '@.*:example\.com' # Cover all local users
 url: null # No event traffic required
 # Stable scope for membership look-up
 scopes: [ "urn:matrix:client:rooms:is_joined" ]
@@ -163,11 +169,38 @@ proxy_prefix: "rtc/livekit" # Proxy /rtc/livekit requests on the C-S and S-S API
 proxy_url: "http://127.0.0.1:1234" # Forward proxied requests to this URL
 ```
 
+## 🚪 Kicking users from the SFU on room leave/ban
+
+[MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195) recommends removing
+participants from the SFU once they leave, or are kicked or banned from, the Matrix room their
+access token was issued for. When running as an application service, the service does this
+by tracking every participant it issues a token for and, every
+`LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS`, reconciling them against the homeserver:
+
+- One `GET /rooms/{roomId}/joined_members` request is made per Matrix room with tracked
+  participants. Connected participants whose user is no longer joined are removed from the
+  LiveKit room. Participants who were issued a token but never connected to the SFU are left
+  alone until they do.
+- Once the homeserver has no local user left in a room, it refuses that request. The service
+  confirms the homeserver's departure via `/is_joined` and then deletes the room's LiveKit
+  rooms outright: only local users can publish on this SFU, so nothing legitimate is left in
+  them. A refusal while the homeserver is still in the room points at a `users` namespace
+  that doesn't match the homeserver's local users and is logged as an error; nothing is
+  removed in that case.
+- Any other failure to determine membership leaves the participants untouched, so a
+  homeserver outage never drops calls.
+
+Tracked participants are persisted in the Redis store, if configured, so that enforcement
+resumes after a restart. Note that this doesn't obsolete short-lived access tokens: a
+participant is only ever removed at the next check, up to one interval after losing their
+membership.
+
 ## 🔌 LiveKit SFU Wiring (Webhooks)
 
 Delegated MatrixRTC leave handling
 ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140))
-relies on participant lifecycle events from the SFU. Point the LiveKit
+and [membership enforcement](#-kicking-users-from-the-sfu-on-room-leaveban)
+rely on participant and room lifecycle events from the SFU. Point the LiveKit
 SFU's webhook receiver at this service's `/sfu_webhook` endpoint in its
 [config.yaml](https://github.com/livekit/livekit/blob/master/config-sample.yaml):
 

--- a/e2e-tests/docker/app-service-a.yaml
+++ b/e2e-tests/docker/app-service-a.yaml
@@ -4,8 +4,13 @@ hs_token: "e2e_hs_token_a"
 sender_localpart: "_lk_jwt_service"
 namespaces:
   users:
+    # Local users only: the service uses /joined_members to enforce room
+    # membership on the SFU, and Synapse serves that endpoint to an
+    # application service as long as any joined member matches this regex.
+    # Matching remote users too would hide the homeserver's own departure
+    # from a room.
     - exclusive: false
-      regex: ".*"
+      regex: '@.*:synapse-a\.e2e\.test'
 # Required for Synapse to call POST /_matrix/app/v1/ping on this service.
 # This will also cause event traffic to be sent to the service, so shouldn't
 # be used in production. For our tests this doesn't matter.

--- a/e2e-tests/docker/app-service-b.yaml
+++ b/e2e-tests/docker/app-service-b.yaml
@@ -4,8 +4,9 @@ hs_token: "e2e_hs_token_b"
 sender_localpart: "_lk_jwt_service"
 namespaces:
   users:
+    # Local users only, see app-service-a.yaml.
     - exclusive: false
-      regex: ".*"
+      regex: '@.*:synapse-b\.e2e\.test'
 # Required for Synapse to call POST /_matrix/app/v1/ping on this service.
 # This will also cause event traffic to be sent to the service, so shouldn't
 # be used in production. For our tests this doesn't matter.

--- a/e2e-tests/docker/docker-compose.yml
+++ b/e2e-tests/docker/docker-compose.yml
@@ -83,6 +83,8 @@ services:
       - LIVEKIT_AS_REGISTRATION_FILE=/etc/lk-jwt-service/app-service-a.yaml
       - LIVEKIT_HS_SERVER_NAME=synapse-a.e2e.test
       - LIVEKIT_CS_API_URL_OVERRIDES=synapse-a.e2e.test=http://synapse-a:8008,synapse-b.e2e.test=http://synapse-b:8008
+      # Short so the membership tests observe kicks quickly.
+      - LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS=2
     volumes:
       - ./app-service-a.yaml:/etc/lk-jwt-service/app-service-a.yaml:ro
     ports:
@@ -104,6 +106,7 @@ services:
       - LIVEKIT_AS_REGISTRATION_FILE=/etc/lk-jwt-service/app-service-b.yaml
       - LIVEKIT_HS_SERVER_NAME=synapse-b.e2e.test
       - LIVEKIT_CS_API_URL_OVERRIDES=synapse-b.e2e.test=http://synapse-b:8008,synapse-a.e2e.test=http://synapse-a:8008
+      - LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS=2
     volumes:
       - ./app-service-b.yaml:/etc/lk-jwt-service/app-service-b.yaml:ro
     ports:

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -207,6 +207,49 @@ pub async fn join_room_via(
     assert!(status.is_success(), "join failed: {status}: {body}");
 }
 
+/// Leaves `room_id` as the given user against the homeserver behind
+/// `cs_api_url`.
+pub async fn leave_room(cs_api_url: &str, user: &MatrixUser, room_id: &str) {
+    let mut url = reqwest::Url::parse(cs_api_url).expect("invalid CS API URL");
+    url.path_segments_mut()
+        .expect("cs_api_url cannot be a base")
+        .extend(["_matrix", "client", "v3", "rooms", room_id, "leave"]);
+
+    let resp = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(&user.access_token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("leave request failed");
+    let status = resp.status();
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .expect("leave response was not valid JSON");
+    assert!(status.is_success(), "leave failed: {status}: {body}");
+}
+
+/// Kicks `target_user_id` out of `room_id` as the given user against the
+/// homeserver behind `cs_api_url`.
+pub async fn kick_user(cs_api_url: &str, user: &MatrixUser, room_id: &str, target_user_id: &str) {
+    let mut url = reqwest::Url::parse(cs_api_url).expect("invalid CS API URL");
+    url.path_segments_mut()
+        .expect("cs_api_url cannot be a base")
+        .extend(["_matrix", "client", "v3", "rooms", room_id, "kick"]);
+
+    let resp = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(&user.access_token)
+        .json(&serde_json::json!({ "user_id": target_user_id, "reason": "e2e test" }))
+        .send()
+        .await
+        .expect("kick request failed");
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.expect("kick response was not valid JSON");
+    assert!(status.is_success(), "kick failed: {status}: {body}");
+}
+
 // ── SFU verification ─────────────────────────────────────────────────────────
 
 /// Connects to the LiveKit SFU at `sfu_addr`'s RTC signalling endpoint using
@@ -336,9 +379,23 @@ impl LiveKitParticipant {
                     }
                     // Drain incoming messages so that the connection stays
                     // responsive (this is also what answers WebSocket pings).
+                    // A Leave from the SFU means it is throwing the
+                    // participant out (or closing the room): the participant
+                    // is gone from that moment on, whether or not the socket
+                    // is closed right away.
                     msg = socket.next() => {
                         match msg {
                             None | Some(Err(_)) => return,
+                            Some(Ok(Message::Binary(bytes))) => {
+                                if let Ok(response) =
+                                    <livekit_protocol::SignalResponse as prost::Message>::decode(&bytes[..])
+                                    && let Some(livekit_protocol::signal_response::Message::Leave(_)) =
+                                        response.message
+                                {
+                                    let _ = socket.close(None).await;
+                                    return;
+                                }
+                            }
                             Some(Ok(_)) => {}
                         }
                     }
@@ -350,6 +407,27 @@ impl LiveKitParticipant {
             leave_tx: Some(leave_tx),
             task,
         }
+    }
+
+    /// Whether the participant is still connected to the SFU, as far as the
+    /// signalling connection can tell: it has neither been closed by the SFU
+    /// nor told to leave.
+    pub fn is_connected(&self) -> bool {
+        !self.task.is_finished()
+    }
+
+    /// Waits until the SFU has disconnected the participant — by telling
+    /// them to leave or by closing the signalling connection — returning
+    /// whether that happened before `timeout` elapsed.
+    pub async fn wait_for_disconnect(&self, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while self.is_connected() {
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        true
     }
 
     /// Leaves the room and waits until the signalling connection is closed.
@@ -468,6 +546,54 @@ pub async fn get_livekit_token(
     assert!(
         status.is_success(),
         "expected a successful get_token response, got {status}: {body}"
+    );
+    body["jwt"]
+        .as_str()
+        .unwrap_or_else(|| panic!("get_token response is missing `jwt`: {body}"))
+        .to_owned()
+}
+
+/// Requests a LiveKit access token for an SFU hosted by `target_server_name`,
+/// a different homeserver than the one behind `cs_api_url`, the way a
+/// federated participant does: through their own homeserver's C-S API, which
+/// relays the request via the MSC4512 federation proxy.
+#[allow(clippy::too_many_arguments)]
+pub async fn get_relayed_livekit_token(
+    cs_api_url: &str,
+    user: &MatrixUser,
+    target_server_name: &str,
+    livekit_url: &str,
+    room_id: &str,
+    slot_id: &str,
+    member_id: &str,
+    device_id: &str,
+) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{cs_api_url}/_matrix/client/unstable/io.element.msc4195/rtc/livekit/get_token"
+        ))
+        .bearer_auth(&user.access_token)
+        .json(&serde_json::json!({
+            "server_name": target_server_name,
+            "room_id": room_id,
+            "slot_id": slot_id,
+            "url": livekit_url,
+            "member": {
+                "id": member_id,
+                "claimed_device_id": device_id,
+            },
+        }))
+        .send()
+        .await
+        .expect("request to /rtc/livekit/get_token failed");
+    let status = resp.status();
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .expect("get_token response was not valid JSON");
+    assert!(
+        status.is_success(),
+        "expected a successful relayed get_token response, got {status}: {body}"
     );
     body["jwt"]
         .as_str()

--- a/e2e-tests/tests/membership_kick.rs
+++ b/e2e-tests/tests/membership_kick.rs
@@ -1,0 +1,175 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+//! Membership enforcement (MSC4195, "Kicking users from the SFU on room
+//! leave/ban") against a real Synapse and a real LiveKit SFU: participants
+//! who leave, or are kicked out of, the Matrix room lose their SFU
+//! connection shortly after.
+
+use std::time::Duration;
+
+use lk_jwt_service_e2e_tests::{
+    LIVEKIT_A_SFU_ADDR, LIVEKIT_A_URL, LiveKitParticipant, SYNAPSE_A_CS_API_URL,
+    SYNAPSE_A_SERVER_NAME, SYNAPSE_B_CS_API_URL, assert_stack_is_up, create_and_join_room,
+    get_livekit_token, get_relayed_livekit_token, join_room_via, kick_user, leave_room,
+    register_user,
+};
+
+const SLOT_ID: &str = "m.call#ROOM";
+
+/// How long a participant gets to be thrown off the SFU after losing their
+/// room membership. The stack runs the membership check every two seconds
+/// (see docker-compose.yml); the rest is headroom for federation and CI.
+const KICK_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long to keep checking that a participant who should stay actually
+/// does. Covers several check intervals.
+const STAY_PERIOD: Duration = Duration::from_secs(5);
+
+/// A local user who is kicked out of the room is removed from the SFU, while
+/// the remaining member stays connected.
+#[tokio::test]
+async fn kicked_user_is_removed_from_sfu() {
+    assert_stack_is_up();
+
+    let alice = register_user(SYNAPSE_A_CS_API_URL, "alice", "e2e-test-password").await;
+    let bob = register_user(SYNAPSE_A_CS_API_URL, "bob", "e2e-test-password").await;
+    let room_id = create_and_join_room(SYNAPSE_A_CS_API_URL, &alice).await;
+    join_room_via(SYNAPSE_A_CS_API_URL, &bob, &room_id, SYNAPSE_A_SERVER_NAME).await;
+
+    let alice_jwt = get_livekit_token(
+        SYNAPSE_A_CS_API_URL,
+        &alice,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-alice",
+        "E2EDEVICEALICE",
+    )
+    .await;
+    let bob_jwt = get_livekit_token(
+        SYNAPSE_A_CS_API_URL,
+        &bob,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-bob",
+        "E2EDEVICEBOB",
+    )
+    .await;
+    let alice_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &alice_jwt).await;
+    let bob_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &bob_jwt).await;
+
+    kick_user(SYNAPSE_A_CS_API_URL, &alice, &room_id, &bob.user_id).await;
+
+    assert!(
+        bob_participant.wait_for_disconnect(KICK_TIMEOUT).await,
+        "expected bob to be removed from the SFU after being kicked from the room"
+    );
+    assert!(
+        !alice_participant.wait_for_disconnect(STAY_PERIOD).await,
+        "expected alice, still a room member, to stay connected"
+    );
+
+    alice_participant.disconnect().await;
+}
+
+/// A federated user who leaves the room is removed from the SFU they were
+/// subscribed on, while the local publisher stays connected.
+#[tokio::test]
+async fn remote_user_leaving_is_removed_from_sfu() {
+    assert_stack_is_up();
+
+    // Alice, on hs A, creates the room and publishes on hs A's SFU.
+    let alice = register_user(SYNAPSE_A_CS_API_URL, "alice", "e2e-test-password").await;
+    let room_id = create_and_join_room(SYNAPSE_A_CS_API_URL, &alice).await;
+    let alice_jwt = get_livekit_token(
+        SYNAPSE_A_CS_API_URL,
+        &alice,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-alice",
+        "E2EDEVICEALICE",
+    )
+    .await;
+    let alice_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &alice_jwt).await;
+
+    // Bob, on hs B, joins the room and subscribes on hs A's SFU with a token
+    // relayed through his own homeserver.
+    let bob = register_user(SYNAPSE_B_CS_API_URL, "bob", "e2e-test-password").await;
+    join_room_via(SYNAPSE_B_CS_API_URL, &bob, &room_id, SYNAPSE_A_SERVER_NAME).await;
+    let bob_jwt = get_relayed_livekit_token(
+        SYNAPSE_B_CS_API_URL,
+        &bob,
+        SYNAPSE_A_SERVER_NAME,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-bob",
+        "E2EDEVICEBOB",
+    )
+    .await;
+    let bob_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &bob_jwt).await;
+
+    leave_room(SYNAPSE_B_CS_API_URL, &bob, &room_id).await;
+
+    assert!(
+        bob_participant.wait_for_disconnect(KICK_TIMEOUT).await,
+        "expected bob to be removed from hs A's SFU after leaving the room"
+    );
+    assert!(
+        !alice_participant.wait_for_disconnect(STAY_PERIOD).await,
+        "expected alice, still a room member, to stay connected"
+    );
+
+    alice_participant.disconnect().await;
+}
+
+/// Once the last local user leaves, the homeserver is out of the room and
+/// can no longer vouch for anyone: the LiveKit room is closed, disconnecting
+/// the remaining federated subscriber.
+#[tokio::test]
+async fn last_local_member_leaving_removes_remaining_participants() {
+    assert_stack_is_up();
+
+    let alice = register_user(SYNAPSE_A_CS_API_URL, "alice", "e2e-test-password").await;
+    let room_id = create_and_join_room(SYNAPSE_A_CS_API_URL, &alice).await;
+    let alice_jwt = get_livekit_token(
+        SYNAPSE_A_CS_API_URL,
+        &alice,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-alice",
+        "E2EDEVICEALICE",
+    )
+    .await;
+    let alice_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &alice_jwt).await;
+
+    let bob = register_user(SYNAPSE_B_CS_API_URL, "bob", "e2e-test-password").await;
+    join_room_via(SYNAPSE_B_CS_API_URL, &bob, &room_id, SYNAPSE_A_SERVER_NAME).await;
+    let bob_jwt = get_relayed_livekit_token(
+        SYNAPSE_B_CS_API_URL,
+        &bob,
+        SYNAPSE_A_SERVER_NAME,
+        LIVEKIT_A_URL,
+        &room_id,
+        SLOT_ID,
+        "e2e-member-bob",
+        "E2EDEVICEBOB",
+    )
+    .await;
+    let bob_participant = LiveKitParticipant::connect(LIVEKIT_A_SFU_ADDR, &bob_jwt).await;
+
+    // Alice hangs up and leaves the room; hs A has no member left in it.
+    alice_participant.disconnect().await;
+    leave_room(SYNAPSE_A_CS_API_URL, &alice, &room_id).await;
+
+    assert!(
+        bob_participant.wait_for_disconnect(KICK_TIMEOUT).await,
+        "expected bob to be disconnected once hs A left the room"
+    );
+}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ livekit-protocol = "0.7.10"
 prost = "0.12"
 rcgen = "0.14"
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde_json = "1"
 sha2 = "0.11.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }

--- a/integration-tests/src/fake_homeserver.rs
+++ b/integration-tests/src/fake_homeserver.rs
@@ -20,6 +20,17 @@ pub struct IsJoinedRequest {
     pub authorization: String,
     pub room_id: String,
     pub mxid: String,
+    pub server_name: String,
+}
+
+/// A request to the /joined_members endpoint.
+#[derive(Clone, Debug)]
+pub struct JoinedMembersRequest {
+    pub authorization: String,
+    pub room_id: String,
+    /// The `user_id` query parameter (application-service identity
+    /// assertion), if any. Expected to be absent.
+    pub user_id: Option<String>,
 }
 
 /// A request to the MSC4512 /fed_proxy endpoint.
@@ -91,6 +102,21 @@ struct HsState {
     /// The recorded /is_joined requests.
     is_joined_requests: Vec<IsJoinedRequest>,
 
+    /// The users /joined_members reports per room. Rooms not listed here
+    /// report no members.
+    joined_members: HashMap<String, Vec<String>>,
+
+    /// Rooms for which /joined_members is refused with 403, as it is for an
+    /// application service none of whose users is in the room.
+    rooms_left: HashSet<String>,
+
+    /// The HTTP status to return on /joined_members requests, overriding the
+    /// scripted members. None results in 200 OK.
+    joined_members_status: Option<u16>,
+
+    /// The recorded /joined_members requests.
+    joined_members_requests: Vec<JoinedMembersRequest>,
+
     /// The recorded /fed_proxy requests.
     fed_proxy_requests: Vec<FedProxyRequest>,
 
@@ -111,6 +137,10 @@ impl Default for HsState {
             delay_look_ups: Vec::new(),
             not_joined: HashSet::new(),
             is_joined_requests: Vec::new(),
+            joined_members: HashMap::new(),
+            rooms_left: HashSet::new(),
+            joined_members_status: None,
+            joined_members_requests: Vec::new(),
             fed_proxy_requests: Vec::new(),
             fed_proxy_response: (
                 200,
@@ -130,6 +160,11 @@ impl FakeHomeserver {
     /// Start a new fake homeserver. The tasks live on the test's tokio runtime and die
     /// with it.
     pub async fn new() -> FakeHomeserver {
+        // Multiple rustls crypto backends are enabled in the dependency
+        // graph, so the default provider must be installed explicitly.
+        // Harmless (and ignored) if another test already installed one.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let state = Arc::new(Mutex::new(HsState::default()));
 
         // Create a throwaway self-signed certificate.
@@ -178,6 +213,10 @@ impl FakeHomeserver {
             .route(
                 "/_matrix/client/unstable/io.element.msc4502/rooms/{room_id}/is_joined",
                 get(handle_is_joined),
+            )
+            .route(
+                "/_matrix/client/v3/rooms/{room_id}/joined_members",
+                get(handle_joined_members),
             )
             .route(
                 "/_matrix/client/unstable/io.element.msc4512/appservice/fed_proxy",
@@ -257,19 +296,52 @@ impl FakeHomeserver {
         self.state.lock().unwrap().delay_look_ups.clone()
     }
 
-    /// Marks (room_id, mxid) as NOT a member of the room. Every other pair
-    /// is treated as joined by default.
-    pub fn set_not_joined(&self, room_id: &str, mxid: &str) {
+    /// Marks (room_id, subject) as NOT a member of the room, where `subject`
+    /// is either an mxid or a server name. Every other pair is treated as
+    /// joined by default.
+    pub fn set_not_joined(&self, room_id: &str, subject: &str) {
         self.state
             .lock()
             .unwrap()
             .not_joined
-            .insert((room_id.to_owned(), mxid.to_owned()));
+            .insert((room_id.to_owned(), subject.to_owned()));
     }
 
     /// The recorded /is_joined requests.
     pub fn is_joined_requests(&self) -> Vec<IsJoinedRequest> {
         self.state.lock().unwrap().is_joined_requests.clone()
+    }
+
+    /// Makes /joined_members report exactly the given users as joined to
+    /// `room_id`. Rooms never set up this way report no members.
+    pub fn set_joined_members(&self, room_id: &str, members: &[&str]) {
+        self.state.lock().unwrap().joined_members.insert(
+            room_id.to_owned(),
+            members.iter().map(|m| (*m).to_owned()).collect(),
+        );
+    }
+
+    /// Makes /joined_members refuse `room_id` with 403, the way a homeserver
+    /// does for an application service none of whose users is in the room.
+    /// Whether the homeserver reports itself as joined via /is_joined is
+    /// controlled separately, see [`FakeHomeserver::set_not_joined`].
+    pub fn set_room_left(&self, room_id: &str) {
+        self.state
+            .lock()
+            .unwrap()
+            .rooms_left
+            .insert(room_id.to_owned());
+    }
+
+    /// Sets the HTTP status /joined_members fails with, regardless of the
+    /// scripted members.
+    pub fn set_joined_members_status(&self, status: u16) {
+        self.state.lock().unwrap().joined_members_status = Some(status);
+    }
+
+    /// The recorded /joined_members requests.
+    pub fn joined_members_requests(&self) -> Vec<JoinedMembersRequest> {
+        self.state.lock().unwrap().joined_members_requests.clone()
     }
 
     /// The recorded /fed_proxy requests.
@@ -407,16 +479,75 @@ async fn handle_is_joined(
         .unwrap_or_default()
         .to_owned();
     let mxid = query.get("mxid").cloned().unwrap_or_default();
+    let server_name = query.get("server_name").cloned().unwrap_or_default();
+    let subject = if !mxid.is_empty() {
+        mxid.clone()
+    } else {
+        server_name.clone()
+    };
 
     let mut state = state.lock().unwrap();
     state.is_joined_requests.push(IsJoinedRequest {
         authorization,
         room_id: room_id.clone(),
-        mxid: mxid.clone(),
+        mxid,
+        server_name,
     });
 
-    let joined = !state.not_joined.contains(&(room_id, mxid));
+    let joined = !state.not_joined.contains(&(room_id, subject));
     Json(json!({ "joined": joined }))
+}
+
+/// Handler for /joined_members requests.
+async fn handle_joined_members(
+    State(state): State<Arc<Mutex<HsState>>>,
+    Path(room_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let authorization = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+
+    let mut state = state.lock().unwrap();
+    state.joined_members_requests.push(JoinedMembersRequest {
+        authorization,
+        room_id: room_id.clone(),
+        user_id: query.get("user_id").cloned(),
+    });
+
+    if let Some(status) = state.joined_members_status {
+        return (
+            StatusCode::from_u16(status).expect("invalid scripted status"),
+            Json(json!({"errcode": "M_UNKNOWN"})),
+        );
+    }
+
+    if state.rooms_left.contains(&room_id) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "errcode": "M_FORBIDDEN",
+                "error": "Appservice not in room",
+            })),
+        );
+    }
+
+    let joined: serde_json::Map<String, serde_json::Value> = state
+        .joined_members
+        .get(&room_id)
+        .into_iter()
+        .flatten()
+        .map(|mxid| {
+            (
+                mxid.clone(),
+                json!({ "display_name": null, "avatar_url": null }),
+            )
+        })
+        .collect();
+    (StatusCode::OK, Json(json!({ "joined": joined })))
 }
 
 /// Handler for /fed_proxy requests (MSC4512).

--- a/integration-tests/src/fake_sfu.rs
+++ b/integration-tests/src/fake_sfu.rs
@@ -31,14 +31,30 @@ pub struct GetParticipantRequest {
     pub identity: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoveParticipantRequest {
+    pub room: String,
+    pub identity: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeleteRoomRequest {
+    pub room: String,
+}
+
 #[derive(Default)]
 struct SfuState {
     /// The recorded RoomService/CreateRoom requests.
     create_room_requests: Vec<CreateRoomRequest>,
     /// The recorded RoomService/GetParticipant requests.
     get_participant_requests: Vec<GetParticipantRequest>,
+    /// The recorded RoomService/RemoveParticipant requests.
+    remove_participant_requests: Vec<RemoveParticipantRequest>,
+    /// The recorded RoomService/DeleteRoom requests.
+    delete_room_requests: Vec<DeleteRoomRequest>,
     /// (room, identity) pairs currently considered present, per
-    /// RoomService/GetParticipant.
+    /// RoomService/GetParticipant. Removed by RemoveParticipant and
+    /// DeleteRoom.
     participants: HashSet<(String, String)>,
 }
 
@@ -67,6 +83,14 @@ impl FakeSfu {
                 "/twirp/livekit.RoomService/GetParticipant",
                 post(handle_get_participant),
             )
+            .route(
+                "/twirp/livekit.RoomService/RemoveParticipant",
+                post(handle_remove_participant),
+            )
+            .route(
+                "/twirp/livekit.RoomService/DeleteRoom",
+                post(handle_delete_room),
+            )
             .with_state(Arc::clone(&state));
         tokio::spawn(axum::serve(listener, app).into_future());
 
@@ -86,6 +110,20 @@ impl FakeSfu {
     /// The recorded RoomService/GetParticipant requests.
     pub fn get_participant_requests(&self) -> Vec<GetParticipantRequest> {
         self.state.lock().unwrap().get_participant_requests.clone()
+    }
+
+    /// The recorded RoomService/RemoveParticipant requests.
+    pub fn remove_participant_requests(&self) -> Vec<RemoveParticipantRequest> {
+        self.state
+            .lock()
+            .unwrap()
+            .remove_participant_requests
+            .clone()
+    }
+
+    /// The recorded RoomService/DeleteRoom requests.
+    pub fn delete_room_requests(&self) -> Vec<DeleteRoomRequest> {
+        self.state.lock().unwrap().delete_room_requests.clone()
     }
 
     /// Mark (room, identity) as present, so GetParticipant succeeds for it.
@@ -193,4 +231,72 @@ async fn handle_get_participant(
         )
             .into_response()
     }
+}
+
+/// Handler for RoomService/RemoveParticipant requests. Removes the
+/// participant from the set of present ones; a participant that is not
+/// present is reported as not_found, like the real SFU does.
+async fn handle_remove_participant(
+    State(state): State<Arc<Mutex<SfuState>>>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Ok(request) = proto::RoomParticipantIdentity::decode(body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "malformed", "msg": "invalid protobuf body" })),
+        )
+            .into_response();
+    };
+
+    let mut state = state.lock().unwrap();
+    state
+        .remove_participant_requests
+        .push(RemoveParticipantRequest {
+            room: request.room.clone(),
+            identity: request.identity.clone(),
+        });
+
+    if state
+        .participants
+        .remove(&(request.room.clone(), request.identity.clone()))
+    {
+        (
+            [(header::CONTENT_TYPE, "application/protobuf")],
+            proto::RemoveParticipantResponse::default().encode_to_vec(),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "code": "not_found", "msg": "participant does not exist" })),
+        )
+            .into_response()
+    }
+}
+
+/// Handler for RoomService/DeleteRoom requests. Removes every participant of
+/// the room from the set of present ones.
+async fn handle_delete_room(
+    State(state): State<Arc<Mutex<SfuState>>>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Ok(request) = proto::DeleteRoomRequest::decode(body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "malformed", "msg": "invalid protobuf body" })),
+        )
+            .into_response();
+    };
+
+    let mut state = state.lock().unwrap();
+    state.delete_room_requests.push(DeleteRoomRequest {
+        room: request.room.clone(),
+    });
+    state.participants.retain(|(room, _)| *room != request.room);
+
+    (
+        [(header::CONTENT_TYPE, "application/protobuf")],
+        proto::DeleteRoomResponse::default().encode_to_vec(),
+    )
+        .into_response()
 }

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -105,6 +105,14 @@ impl Service {
                 "YES_I_KNOW_WHAT_I_AM_DOING".into(),
             ),
             ("LIVEKIT_LOG_LEVEL".into(), "debug".into()),
+            // Membership enforcement is opt-in per test (via extra_env):
+            // most tests don't script /joined_members on the fake
+            // homeserver, and the default interval would otherwise have the
+            // service poll it in the background.
+            (
+                "LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS".into(),
+                "0".into(),
+            ),
         ]);
 
         if !cfg.cs_api_url_overrides.is_empty() {

--- a/integration-tests/src/helpers.rs
+++ b/integration-tests/src/helpers.rs
@@ -13,9 +13,11 @@ use sha2::{Digest, Sha256};
 
 use crate::fake_homeserver::FakeHomeserver;
 use crate::fake_redis::FakeRedis;
+use crate::fake_sfu::FakeSfu;
 use crate::harness::{LIVEKIT_KEY, LIVEKIT_SECRET, Service};
 
 const REDIS_JOBS_HASH_KEY: &str = "lk-jwt:jobs";
+const REDIS_PARTICIPANTS_HASH_KEY: &str = "lk-jwt:participants";
 
 /// Decode a LiveKit JWT issued with the service's API secret and return
 /// its claims.
@@ -243,6 +245,24 @@ pub fn expect_no_is_joined_request(hs: &FakeHomeserver, room_id: &str, mxid: &st
     );
 }
 
+/// Assert that an /is_joined request for the given room and server name has been
+/// recorded with the given `as_token` as its authorization.
+#[track_caller]
+pub fn expect_server_is_joined_request(
+    hs: &FakeHomeserver,
+    room_id: &str,
+    server_name: &str,
+    as_token: &str,
+) {
+    let requests = hs.is_joined_requests();
+    assert!(
+        requests.iter().any(|r| r.room_id == room_id
+            && r.server_name == server_name
+            && r.authorization == format!("Bearer {as_token}")),
+        "expected an is_joined request for room {room_id:?}, server_name {server_name:?}, as_token {as_token:?}, got {requests:?}"
+    );
+}
+
 /// Assert that no fed_proxy request has been recorded.
 #[track_caller]
 pub fn expect_no_fed_proxy_requests(hs: &FakeHomeserver) {
@@ -339,6 +359,169 @@ pub async fn wait_for_job_removed(
         if Instant::now() >= deadline {
             panic!(
                 "timed out waiting for the job (room {room:?}, identity {identity:?}) to be removed from the store"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Assert that a /joined_members request for the given room has been
+/// recorded, authenticated with `as_token` and without an identity
+/// assertion.
+#[track_caller]
+pub fn expect_joined_members_request(hs: &FakeHomeserver, room_id: &str, as_token: &str) {
+    let requests = hs.joined_members_requests();
+    assert!(
+        requests.iter().any(|r| r.room_id == room_id
+            && r.authorization == format!("Bearer {as_token}")
+            && r.user_id.is_none()),
+        "expected a joined_members request for room {room_id:?} authenticated with as_token \
+         {as_token:?} and no user_id, got {requests:?}"
+    );
+}
+
+/// Assert that no /joined_members request has been recorded.
+#[track_caller]
+pub fn expect_no_joined_members_requests(hs: &FakeHomeserver) {
+    let requests = hs.joined_members_requests();
+    assert!(
+        requests.is_empty(),
+        "expected no joined_members requests, got {requests:?}"
+    );
+}
+
+/// Poll until a /joined_members request for the given room has been
+/// recorded, or panic once the timeout elapses.
+pub async fn wait_for_joined_members_request(
+    hs: &FakeHomeserver,
+    room_id: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if hs
+            .joined_members_requests()
+            .iter()
+            .any(|r| r.room_id == room_id)
+        {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for a joined_members request for room {room_id:?}, got {:?}",
+                hs.joined_members_requests()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Poll until a RoomService/RemoveParticipant request for the given room
+/// and identity has been recorded, or panic once the timeout elapses.
+pub async fn wait_for_remove_participant_request(
+    sfu: &FakeSfu,
+    room: &str,
+    identity: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if sfu
+            .remove_participant_requests()
+            .iter()
+            .any(|r| r.room == room && r.identity == identity)
+        {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for a RemoveParticipant request for room {room:?}, identity \
+                 {identity:?}, got {:?}",
+                sfu.remove_participant_requests()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Assert that no RoomService/RemoveParticipant request has been recorded.
+#[track_caller]
+pub fn expect_no_remove_participant_requests(sfu: &FakeSfu) {
+    let requests = sfu.remove_participant_requests();
+    assert!(
+        requests.is_empty(),
+        "expected no RemoveParticipant requests, got {requests:?}"
+    );
+}
+
+/// Poll until a RoomService/DeleteRoom request for the given room has been
+/// recorded, or panic once the timeout elapses.
+pub async fn wait_for_delete_room_request(sfu: &FakeSfu, room: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if sfu.delete_room_requests().iter().any(|r| r.room == room) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for a DeleteRoom request for room {room:?}, got {:?}",
+                sfu.delete_room_requests()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Assert that no RoomService/DeleteRoom request has been recorded.
+#[track_caller]
+pub fn expect_no_delete_room_requests(sfu: &FakeSfu) {
+    let requests = sfu.delete_room_requests();
+    assert!(
+        requests.is_empty(),
+        "expected no DeleteRoom requests, got {requests:?}"
+    );
+}
+
+/// Poll until a participant for the given room and identity is persisted,
+/// or panic once the timeout elapses.
+pub async fn wait_for_participant_persisted(
+    redis: &FakeRedis,
+    room: &str,
+    identity: &str,
+    timeout: Duration,
+) {
+    let field = redis_job_field(room, identity);
+    let deadline = Instant::now() + timeout;
+    loop {
+        if redis.hash_field_exists(REDIS_PARTICIPANTS_HASH_KEY, &field) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for the participant (room {room:?}, identity {identity:?}) to be persisted"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Poll until the participant for the given room and identity is no longer
+/// persisted, or panic once the timeout elapses.
+pub async fn wait_for_participant_removed(
+    redis: &FakeRedis,
+    room: &str,
+    identity: &str,
+    timeout: Duration,
+) {
+    let field = redis_job_field(room, identity);
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !redis.hash_field_exists(REDIS_PARTICIPANTS_HASH_KEY, &field) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for the participant (room {room:?}, identity {identity:?}) to be removed from the store"
             );
         }
         tokio::time::sleep(Duration::from_millis(50)).await;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -11,18 +11,24 @@ mod helpers;
 
 pub use fake_homeserver::{
     DelayedEventLookup, DelayedEventRequest, FakeHomeserver, FakeUser, FedProxyRequest,
-    IsJoinedRequest, UserInfoRequest,
+    IsJoinedRequest, JoinedMembersRequest, UserInfoRequest,
 };
 pub use fake_redis::FakeRedis;
-pub use fake_sfu::{CreateRoomRequest, FakeSfu, GetParticipantRequest};
+pub use fake_sfu::{
+    CreateRoomRequest, DeleteRoomRequest, FakeSfu, GetParticipantRequest, RemoveParticipantRequest,
+};
 pub use harness::{DEFAULT_LK_URL, LIVEKIT_KEY, LIVEKIT_SECRET, Service, ServiceConfig};
 pub use helpers::{
     decode_livekit_jwt, expect_delayed_event_request, expect_delayed_event_request_count,
     expect_delayed_event_request_identity, expect_fed_proxy_request, expect_is_joined_request,
-    expect_job_not_persisted, expect_job_persisted, expect_matrix_error,
-    expect_no_delayed_event_request, expect_no_delayed_event_requests,
-    expect_no_fed_proxy_requests, expect_no_is_joined_request, expect_no_is_joined_requests,
-    expect_no_user_info_lookups, expect_user_info_lookup, livekit_identity, livekit_room_alias,
+    expect_job_not_persisted, expect_job_persisted, expect_joined_members_request,
+    expect_matrix_error, expect_no_delayed_event_request, expect_no_delayed_event_requests,
+    expect_no_delete_room_requests, expect_no_fed_proxy_requests, expect_no_is_joined_request,
+    expect_no_is_joined_requests, expect_no_joined_members_requests,
+    expect_no_remove_participant_requests, expect_no_user_info_lookups,
+    expect_server_is_joined_request, expect_user_info_lookup, livekit_identity, livekit_room_alias,
     send_sfu_webhook, wait_for_delayed_event_request, wait_for_delayed_event_request_count,
-    wait_for_job_removed,
+    wait_for_delete_room_request, wait_for_job_removed, wait_for_joined_members_request,
+    wait_for_participant_persisted, wait_for_participant_removed,
+    wait_for_remove_participant_request,
 };

--- a/integration-tests/tests/membership_check.rs
+++ b/integration-tests/tests/membership_check.rs
@@ -1,0 +1,384 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+//! Membership enforcement (MSC4195, "Kicking users from the SFU on room
+//! leave/ban"): the service periodically reconciles the participants it
+//! issued tokens for against the homeserver's `/joined_members` and removes
+//! those who lost their room membership from the SFU.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use lk_jwt_service_integration_tests::{
+    FakeHomeserver, FakeRedis, FakeSfu, Service, ServiceConfig, expect_joined_members_request,
+    expect_no_delete_room_requests, expect_no_joined_members_requests,
+    expect_no_remove_participant_requests, livekit_identity, livekit_room_alias, send_sfu_webhook,
+    wait_for_delete_room_request, wait_for_joined_members_request, wait_for_participant_persisted,
+    wait_for_participant_removed, wait_for_remove_participant_request,
+};
+use serde_json::{Value, json};
+
+const AS_TOKEN: &str = "as_token";
+const HS_TOKEN: &str = "hs_token";
+const ORIGIN_SERVER: &str = "origin.example.org";
+
+const ROOM_ID: &str = "!room:example.com";
+const SLOT_ID: &str = "m.call#";
+
+const GET_TOKEN_CS_PATH: &str = "/_matrix/client/unstable/io.element.msc4195/rtc/livekit/get_token";
+const GET_TOKEN_SS_PATH: &str =
+    "/_matrix/federation/unstable/io.element.msc4195/rtc/livekit/get_token";
+
+/// How long to wait for the service to act on a membership change. The
+/// check interval in these tests is one second, so this leaves plenty of
+/// headroom for CI.
+const ENFORCEMENT_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// How long to wait before concluding that the service did *not* act. Covers
+/// two check intervals.
+const QUIET_PERIOD: Duration = Duration::from_millis(2500);
+
+/// App-service configuration with the membership check running every
+/// `interval_secs` seconds, as extra_env.
+fn app_service_env(hs_server_name: &str, interval_secs: u64) -> HashMap<String, String> {
+    HashMap::from([
+        ("LIVEKIT_AS_TOKEN".to_owned(), AS_TOKEN.to_owned()),
+        ("LIVEKIT_HS_TOKEN".to_owned(), HS_TOKEN.to_owned()),
+        (
+            "LIVEKIT_HS_SERVER_NAME".to_owned(),
+            hs_server_name.to_owned(),
+        ),
+        (
+            "LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS".to_owned(),
+            interval_secs.to_string(),
+        ),
+    ])
+}
+
+/// The full service configuration these tests use: a fake homeserver, a fake
+/// SFU and the membership check every second.
+fn service_config(hs: &FakeHomeserver, sfu: &FakeSfu, redis: Option<&FakeRedis>) -> ServiceConfig {
+    ServiceConfig {
+        full_access_homeservers: vec!["*".to_owned()],
+        cs_api_url_overrides: hs.cs_api_url_override(),
+        livekit_url: Some(sfu.url().to_owned()),
+        redis_url: redis.map(|r| r.url().to_owned()),
+        extra_env: app_service_env(hs.server_name(), 1),
+    }
+}
+
+/// Mints a token for `user_id` via the C-S endpoint (a local user) and
+/// returns the LiveKit (room, identity) it was issued for.
+async fn mint_local_token(
+    svc: &Service,
+    sfu: &FakeSfu,
+    user_id: &str,
+    member_id: &str,
+) -> (String, String) {
+    let body: Value = json!({
+        "url": sfu.url(),
+        "room_id": ROOM_ID,
+        "slot_id": SLOT_ID,
+        "member": {
+            "id": member_id,
+            "claimed_user_id": user_id,
+            "claimed_device_id": "DEVICE",
+        },
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}{GET_TOKEN_CS_PATH}", svc.base_url))
+        .header("Content-Type", "application/json")
+        .header("X-Matrix-User-Identifier", user_id)
+        .header("Authorization", format!("Bearer {HS_TOKEN}"))
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("request failed");
+    let status = resp.status().as_u16();
+    let text = resp.text().await.expect("failed to read response body");
+    assert_eq!(status, 200, "minting a local token failed: {text}");
+    (
+        livekit_room_alias(ROOM_ID, SLOT_ID),
+        livekit_identity(user_id, "DEVICE", member_id),
+    )
+}
+
+/// Mints a token for the remote `user_id` via the S-S endpoint and returns
+/// the LiveKit (room, identity) it was issued for.
+async fn mint_remote_token(
+    svc: &Service,
+    sfu: &FakeSfu,
+    user_id: &str,
+    member_id: &str,
+) -> (String, String) {
+    let body: Value = json!({
+        "url": sfu.url(),
+        "user_id": user_id,
+        "room_id": ROOM_ID,
+        "slot_id": SLOT_ID,
+        "member": {
+            "id": member_id,
+            "claimed_device_id": "DEVICE",
+        },
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}{GET_TOKEN_SS_PATH}", svc.base_url))
+        .header("Content-Type", "application/json")
+        .header("X-Matrix-Origin", ORIGIN_SERVER)
+        .header("Authorization", format!("Bearer {HS_TOKEN}"))
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("request failed");
+    let status = resp.status().as_u16();
+    let text = resp.text().await.expect("failed to read response body");
+    assert_eq!(status, 200, "minting a remote token failed: {text}");
+    (
+        livekit_room_alias(ROOM_ID, SLOT_ID),
+        livekit_identity(user_id, "DEVICE", member_id),
+    )
+}
+
+/// Reports `identity` as connected to `room`: present on the SFU and
+/// announced through a webhook, like a real connect.
+async fn connect(svc: &Service, sfu: &FakeSfu, room: &str, identity: &str) {
+    sfu.set_participant_present(room, identity);
+    send_sfu_webhook(svc, "participant_joined", room, identity, None).await;
+}
+
+/// A connected local participant whose user left the room is removed from
+/// the SFU. The membership query authenticates as the application service
+/// itself.
+#[tokio::test]
+async fn non_member_is_removed_from_sfu() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    connect(&svc, &sfu, &room, &identity).await;
+
+    // Still a member: the service checks, but leaves the participant be.
+    wait_for_joined_members_request(&hs, ROOM_ID, ENFORCEMENT_TIMEOUT).await;
+    expect_joined_members_request(&hs, ROOM_ID, AS_TOKEN);
+    expect_no_remove_participant_requests(&sfu);
+
+    // Alice leaves the room.
+    hs.set_joined_members(ROOM_ID, &[]);
+    wait_for_remove_participant_request(&sfu, &room, &identity, ENFORCEMENT_TIMEOUT).await;
+    expect_no_delete_room_requests(&sfu);
+}
+
+/// A connected participant whose user stays in the room is left alone.
+#[tokio::test]
+async fn member_stays_connected() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id, "@someone-else:example.com"]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    connect(&svc, &sfu, &room, &identity).await;
+
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_joined_members_request(&hs, ROOM_ID, AS_TOKEN);
+    expect_no_remove_participant_requests(&sfu);
+    expect_no_delete_room_requests(&sfu);
+}
+
+/// A federated participant, whose token was minted via the S-S endpoint, is
+/// removed from the SFU once they leave the room — even while local users
+/// remain.
+#[tokio::test]
+async fn remote_participant_is_removed_when_leaving() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    let bob = format!("@bob:{ORIGIN_SERVER}");
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id, &bob]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, alice_identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    let (_, bob_identity) = mint_remote_token(&svc, &sfu, &bob, "member-2").await;
+    connect(&svc, &sfu, &room, &alice_identity).await;
+    connect(&svc, &sfu, &room, &bob_identity).await;
+
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id]);
+    wait_for_remove_participant_request(&sfu, &room, &bob_identity, ENFORCEMENT_TIMEOUT).await;
+
+    let removed = sfu.remove_participant_requests();
+    assert!(
+        removed.iter().all(|r| r.identity == bob_identity),
+        "expected only bob to be removed, got {removed:?}"
+    );
+    expect_no_delete_room_requests(&sfu);
+}
+
+/// Once the homeserver itself has left the room — the membership query is
+/// refused and MSC4502 confirms the server is gone — the LiveKit room is
+/// deleted, taking every remaining participant with it.
+#[tokio::test]
+async fn homeserver_leaving_room_deletes_livekit_room() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    let bob = format!("@bob:{ORIGIN_SERVER}");
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id, &bob]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, alice_identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    let (_, bob_identity) = mint_remote_token(&svc, &sfu, &bob, "member-2").await;
+    connect(&svc, &sfu, &room, &alice_identity).await;
+    connect(&svc, &sfu, &room, &bob_identity).await;
+
+    // Alice, the last local user, leaves: the homeserver is out of the room.
+    hs.set_room_left(ROOM_ID);
+    hs.set_not_joined(ROOM_ID, hs.server_name());
+    wait_for_delete_room_request(&sfu, &room, ENFORCEMENT_TIMEOUT).await;
+    expect_no_remove_participant_requests(&sfu);
+}
+
+/// A refused membership query while the homeserver is still in the room
+/// points at a misconfigured user namespace, not at anyone having left:
+/// nothing is removed.
+#[tokio::test]
+async fn refused_membership_query_with_server_joined_fails_open() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_room_left(ROOM_ID);
+    // /is_joined reports every subject joined by default, the server too.
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    connect(&svc, &sfu, &room, &identity).await;
+
+    wait_for_joined_members_request(&hs, ROOM_ID, ENFORCEMENT_TIMEOUT).await;
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_no_remove_participant_requests(&sfu);
+    expect_no_delete_room_requests(&sfu);
+}
+
+/// A homeserver that cannot answer the membership query leaves everyone
+/// connected.
+#[tokio::test]
+async fn homeserver_error_fails_open() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members_status(503);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    connect(&svc, &sfu, &room, &identity).await;
+
+    wait_for_joined_members_request(&hs, ROOM_ID, ENFORCEMENT_TIMEOUT).await;
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_no_remove_participant_requests(&sfu);
+    expect_no_delete_room_requests(&sfu);
+}
+
+/// A participant the SFU reported as having left is no longer tracked, so a
+/// later loss of membership has nothing to act on — and nothing left to
+/// query for.
+#[tokio::test]
+async fn participant_left_webhook_stops_tracking() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members(ROOM_ID, &[]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    // Left before the first check ran, as reported by the SFU.
+    send_sfu_webhook(
+        &svc,
+        "participant_left",
+        &room,
+        &identity,
+        Some("CLIENT_INITIATED"),
+    )
+    .await;
+    // Still on the SFU as far as GetParticipant is concerned, to prove that
+    // the service does not go looking.
+    sfu.set_participant_present(&room, &identity);
+
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_no_joined_members_requests(&hs);
+    expect_no_remove_participant_requests(&sfu);
+}
+
+/// A participant who was issued a token but never connected is not removed;
+/// the removal happens once the SFU reports them present — a missed join
+/// webhook only delays it.
+#[tokio::test]
+async fn pending_participant_is_removed_once_connected() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members(ROOM_ID, &[]);
+
+    let svc = Service::start(service_config(&hs, &sfu, None)).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+
+    // Absent from the SFU: nothing to remove.
+    wait_for_joined_members_request(&hs, ROOM_ID, ENFORCEMENT_TIMEOUT).await;
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_no_remove_participant_requests(&sfu);
+
+    // Present on the SFU, without any webhook saying so.
+    sfu.set_participant_present(&room, &identity);
+    wait_for_remove_participant_request(&sfu, &room, &identity, ENFORCEMENT_TIMEOUT).await;
+}
+
+/// Tracked participants are persisted and picked up again by a restarted
+/// service, which then enforces membership for them as usual and removes
+/// them from the store once done.
+#[tokio::test]
+async fn tracked_participants_survive_restart() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    let redis = FakeRedis::new().await;
+    hs.set_joined_members(ROOM_ID, &[&alice.user_id]);
+
+    let (room, identity) = {
+        let svc = Service::start(service_config(&hs, &sfu, Some(&redis))).await;
+        let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+        connect(&svc, &sfu, &room, &identity).await;
+        wait_for_participant_persisted(&redis, &room, &identity, ENFORCEMENT_TIMEOUT).await;
+        (room, identity)
+        // The service is killed here.
+    };
+
+    // Alice leaves while the service is down.
+    hs.set_joined_members(ROOM_ID, &[]);
+
+    let _svc = Service::start(service_config(&hs, &sfu, Some(&redis))).await;
+    wait_for_remove_participant_request(&sfu, &room, &identity, ENFORCEMENT_TIMEOUT).await;
+    wait_for_participant_removed(&redis, &room, &identity, ENFORCEMENT_TIMEOUT).await;
+}
+
+/// A zero check interval disables membership enforcement entirely.
+#[tokio::test]
+async fn zero_interval_disables_enforcement() {
+    let hs = FakeHomeserver::new().await;
+    let alice = hs.new_user("alice");
+    let sfu = FakeSfu::new().await;
+    hs.set_joined_members(ROOM_ID, &[]);
+
+    let mut config = service_config(&hs, &sfu, None);
+    config.extra_env = app_service_env(hs.server_name(), 0);
+    let svc = Service::start(config).await;
+    let (room, identity) = mint_local_token(&svc, &sfu, &alice.user_id, "member-1").await;
+    connect(&svc, &sfu, &room, &identity).await;
+
+    tokio::time::sleep(QUIET_PERIOD).await;
+    expect_no_joined_members_requests(&hs);
+    expect_no_remove_participant_requests(&sfu);
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,12 @@ pub struct Config {
     /// the sanity check entirely.
     /// Configure via LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS (unit: seconds).
     pub sanity_check_interval: Duration,
+    /// The period at which SFU participants are reconciled against Matrix
+    /// room membership, removing those who left or were kicked or banned
+    /// (MSC4195). Zero disables the check. Only effective when running as an
+    /// application service.
+    /// Configure via LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS (unit: seconds).
+    pub membership_check_interval: Duration,
     /// Map of URLs for the Client-Server API keyed by server name. These will
     /// be preferred over .well-known resolution for the contained server names.
     pub cs_api_url_overrides: HashMap<String, CsApiUrl>,
@@ -233,20 +239,8 @@ pub fn parse_config() -> Result<Config, String> {
 
     let lk_jwt_bind = parse_bind()?;
 
-    let mut sanity_check_interval = Duration::ZERO;
-    let sanity_check_raw = env_var("LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS");
-    if !sanity_check_raw.is_empty() {
-        match sanity_check_raw.parse::<i64>() {
-            Ok(secs) if secs >= 0 => {
-                sanity_check_interval = Duration::from_secs(secs as u64);
-            }
-            _ => {
-                return Err(format!(
-                    "LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS must be a non-negative integer, got {sanity_check_raw:?}"
-                ));
-            }
-        }
-    }
+    let sanity_check_interval =
+        read_interval_seconds("LIVEKIT_SANITY_CHECK_INTERVAL_SECONDS")?.unwrap_or(Duration::ZERO);
 
     let cs_api_url_overrides = read_cs_api_url_overrides(&env_var("LIVEKIT_CS_API_URL_OVERRIDES"))
         .map_err(|e| format!("failed parsing LIVEKIT_CS_API_URL_OVERRIDES: {e}"))?;
@@ -276,6 +270,20 @@ pub fn parse_config() -> Result<Config, String> {
         };
     }
 
+    let membership_check_interval =
+        match read_interval_seconds("LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS")? {
+            Some(interval) => {
+                if !interval.is_zero() && !app_service_config.is_set_up() {
+                    warn!(
+                        "LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS has no effect unless running as \
+                         an application service"
+                    );
+                }
+                interval
+            }
+            None => DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
+        };
+
     Ok(Config {
         key,
         secret,
@@ -288,10 +296,31 @@ pub fn parse_config() -> Result<Config, String> {
             .collect(),
         lk_jwt_bind,
         sanity_check_interval,
+        membership_check_interval,
         cs_api_url_overrides,
         redis_url: redis_url_string,
         app_service_config,
     })
+}
+
+/// The membership check interval used when
+/// LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS is unset.
+pub const DEFAULT_MEMBERSHIP_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Reads an interval in whole seconds from the environment variable `name`.
+/// Returns None when the variable is unset or empty and an error when it is
+/// set to anything but a non-negative integer.
+fn read_interval_seconds(name: &str) -> Result<Option<Duration>, String> {
+    let raw = env_var(name);
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    match raw.parse::<i64>() {
+        Ok(secs) if secs >= 0 => Ok(Some(Duration::from_secs(secs as u64))),
+        _ => Err(format!(
+            "{name} must be a non-negative integer, got {raw:?}"
+        )),
+    }
 }
 
 /// Expands a bind address into the socket addresses to try, in order. A bare
@@ -721,6 +750,7 @@ mod tests {
                     full_access_homeservers: vec!["*".into()],
                     lk_jwt_bind: ":8080".into(),
                     sanity_check_interval: Duration::ZERO,
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                     cs_api_url_overrides: HashMap::new(),
                     redis_url: String::new(),
                     app_service_config: Default::default(),
@@ -761,6 +791,7 @@ mod tests {
                     full_access_homeservers: vec!["example.com".into(), "test.com".into()],
                     lk_jwt_bind: ":9090".into(),
                     sanity_check_interval: Duration::from_secs(30),
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                     cs_api_url_overrides: HashMap::from([(
                         "matrix.com".to_owned(),
                         CsApiUrl("https://matrix-client.matrix.com".into()),
@@ -791,6 +822,7 @@ mod tests {
                     full_access_homeservers: vec!["*".into()],
                     lk_jwt_bind: ":9090".into(),
                     sanity_check_interval: Duration::ZERO,
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                     cs_api_url_overrides: HashMap::new(),
                     redis_url: String::new(),
                     app_service_config: Default::default(),
@@ -870,11 +902,72 @@ mod tests {
                     full_access_homeservers: vec!["*".into()],
                     lk_jwt_bind: ":8080".into(),
                     sanity_check_interval: Duration::ZERO,
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                     cs_api_url_overrides: HashMap::new(),
                     redis_url: String::new(),
                     app_service_config: Default::default(),
                 }),
                 want_err_msg: "",
+            },
+            Case {
+                name: "Membership check interval set",
+                env: vec![
+                    ("LIVEKIT_KEY", "test_key"),
+                    ("LIVEKIT_SECRET", "test_secret"),
+                    ("LIVEKIT_URL", "wss://test.livekit.cloud"),
+                    ("LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS", "5"),
+                    ("LIVEKIT_FULL_ACCESS_HOMESERVERS", "*"),
+                ],
+                want_config: Some(Config {
+                    key: "test_key".into(),
+                    secret: "test_secret".into(),
+                    lk_url: "wss://test.livekit.cloud".into(),
+                    skip_verify_tls: false,
+                    full_access_homeservers: vec!["*".into()],
+                    lk_jwt_bind: ":8080".into(),
+                    sanity_check_interval: Duration::ZERO,
+                    membership_check_interval: Duration::from_secs(5),
+                    cs_api_url_overrides: HashMap::new(),
+                    redis_url: String::new(),
+                    app_service_config: Default::default(),
+                }),
+                want_err_msg: "",
+            },
+            Case {
+                name: "Membership check interval zero disables",
+                env: vec![
+                    ("LIVEKIT_KEY", "test_key"),
+                    ("LIVEKIT_SECRET", "test_secret"),
+                    ("LIVEKIT_URL", "wss://test.livekit.cloud"),
+                    ("LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS", "0"),
+                    ("LIVEKIT_FULL_ACCESS_HOMESERVERS", "*"),
+                ],
+                want_config: Some(Config {
+                    key: "test_key".into(),
+                    secret: "test_secret".into(),
+                    lk_url: "wss://test.livekit.cloud".into(),
+                    skip_verify_tls: false,
+                    full_access_homeservers: vec!["*".into()],
+                    lk_jwt_bind: ":8080".into(),
+                    sanity_check_interval: Duration::ZERO,
+                    membership_check_interval: Duration::ZERO,
+                    cs_api_url_overrides: HashMap::new(),
+                    redis_url: String::new(),
+                    app_service_config: Default::default(),
+                }),
+                want_err_msg: "",
+            },
+            Case {
+                name: "Membership check interval invalid",
+                env: vec![
+                    ("LIVEKIT_KEY", "test_key"),
+                    ("LIVEKIT_SECRET", "test_secret"),
+                    ("LIVEKIT_URL", "wss://test.livekit.cloud"),
+                    ("LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS", "soon"),
+                    ("LIVEKIT_FULL_ACCESS_HOMESERVERS", "*"),
+                ],
+                want_config: None,
+                want_err_msg: "LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS must be a non-negative integer, got \"soon\"",
             },
             Case {
                 name: "Sanity check interval negative rejected",
@@ -908,6 +1001,7 @@ mod tests {
                     cs_api_url_overrides: HashMap::new(),
                     redis_url: "redis://localhost:6379".to_owned(),
                     app_service_config: Default::default(),
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                 }),
                 want_err_msg: "",
             },
@@ -935,6 +1029,7 @@ mod tests {
                     redis_url: "redis://:redis_cred_ua5ahg7ahruek4sho6ateeFe@localhost:6379"
                         .to_owned(),
                     app_service_config: Default::default(),
+                    membership_check_interval: DEFAULT_MEMBERSHIP_CHECK_INTERVAL,
                 }),
                 want_err_msg: "",
             },

--- a/src/delayed_event_manager.rs
+++ b/src/delayed_event_manager.rs
@@ -20,7 +20,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::helper::{
-    CsApiUrl, Deps, LiveKitAuth, LiveKitIdentity, LiveKitRoomAlias, UniqueId, new_unique_id,
+    CsApiUrl, Deps, LiveKitAuth, LiveKitIdentity, LiveKitRoomAlias, ParticipantKey, UniqueId,
+    new_unique_id,
 };
 use crate::retry::{Classify, ErrorClass, ExponentialBackoff, RetryError, retry};
 
@@ -125,14 +126,9 @@ pub struct SfuMessage {
     pub livekit_identity: LiveKitIdentity,
 }
 
-/// The map key used by the handler loop to track active delayed-event jobs.
-/// LiveKit identity encodes the Matrix user ID (which includes the homeserver
-/// domain), so (room, identity) is unique — no need for CsApiUrl in the key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct JobKey {
-    pub room: LiveKitRoomAlias,
-    pub identity: LiveKitIdentity,
-}
+/// The map key used by the handler loop to track active delayed-event jobs:
+/// the (LiveKit room, LiveKit identity) pair the job is for.
+pub type JobKey = ParticipantKey;
 
 /// Resolves the Client-Server API base URL for a homeserver.
 pub type LookupCsApiUrlFn =

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -34,8 +34,11 @@ use crate::delayed_event_manager::{
 use crate::helper::new_unique_id;
 use crate::helper::{
     CsApiUrl, CsApiUrlCache, Deps, FederationTokenError, GET_TOKEN_SS_PATH, LiveKitAuth,
-    LiveKitIdentity, LiveKitRoomAlias, UniqueId, livekit_identity_for, livekit_room_alias_for,
-    matrix_server_name,
+    LiveKitIdentity, LiveKitRoomAlias, ParticipantKey, UniqueId, livekit_identity_for,
+    livekit_room_alias_for, matrix_server_name,
+};
+use crate::membership_monitor::{
+    MembershipMonitor, MembershipMonitorConfig, Registration, SfuEvent,
 };
 #[cfg(feature = "appservice-ping-trigger")]
 use crate::requests::AppservicePingTriggerRequest;
@@ -114,6 +117,25 @@ pub(crate) struct LoopReceivers {
     pub(crate) sfu_event_rx: mpsc::Receiver<SfuEventRequest>,
     job_done_rx: mpsc::Receiver<Arc<DelayedEventJob>>,
     job_restarted_rx: mpsc::Receiver<JobRestartedRequest>,
+    /// Participants the membership monitor removed from the SFU.
+    revoked_rx: mpsc::Receiver<ParticipantKey>,
+}
+
+/// Builds a CS-API URL resolver backed by the given overrides and cache.
+fn make_lookup_fn(
+    deps: Arc<dyn Deps>,
+    overrides: Arc<HashMap<String, CsApiUrl>>,
+    cache: Arc<CsApiUrlCache>,
+) -> LookupCsApiUrlFn {
+    Arc::new(move |server_name| {
+        let deps = deps.clone();
+        let overrides = overrides.clone();
+        let cache = cache.clone();
+        Box::pin(async move {
+            deps.resolve_cs_api_url(&server_name, &overrides, Some(&cache))
+                .await
+        })
+    })
 }
 
 /// A persistence operation queued for the store-writer task.
@@ -152,6 +174,11 @@ pub(crate) enum AddJobError {
 ///   - sfu_event: route an SFU webhook event to the job for (room, identity)
 ///   - job_done: clean up a job that reached a terminal state
 ///   - job_restarted: update the stored job after a delayed-event restart
+///   - revoked: stop the job of a participant the membership monitor removed
+///
+/// Membership enforcement (MSC4195's kick on room leave/ban) lives in a
+/// separate actor, the [`MembershipMonitor`], which is only present when
+/// running as an application service with a non-zero check interval.
 pub struct Handler {
     cancel: CancellationToken,
     pub(crate) livekit_auth: LiveKitAuth,
@@ -174,14 +201,20 @@ pub struct Handler {
     job_restarted_tx: mpsc::Sender<JobRestartedRequest>,
     add_job_tx: mpsc::Sender<AddJobRequest>,
     pub(crate) sfu_event_tx: mpsc::Sender<SfuEventRequest>,
+    /// Enforces room membership on the SFU. None when not running as an
+    /// application service or when disabled via a zero check interval. Owns
+    /// the sending end of the loop's `revoked` channel.
+    membership_monitor: Option<Arc<MembershipMonitor>>,
 }
 
 impl Handler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         lk_auth: LiveKitAuth,
         full_access_homeservers: Vec<String>,
         app_service_config: AppServiceConfig,
         sanity_check_interval: Duration,
+        membership_check_interval: Duration,
         cs_api_url_overrides: HashMap<String, CsApiUrl>,
         store: Option<Arc<dyn Store>>,
         deps: Arc<dyn Deps>,
@@ -191,6 +224,7 @@ impl Handler {
             full_access_homeservers,
             app_service_config,
             sanity_check_interval,
+            membership_check_interval,
             cs_api_url_overrides,
             store,
             deps,
@@ -201,12 +235,15 @@ impl Handler {
     }
 
     /// Constructs a Handler without starting its actor loop, handing the
-    /// loop's receiving ends to the caller.
+    /// loop's receiving ends to the caller. The membership monitor, if any,
+    /// is started regardless.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_without_loop(
         lk_auth: LiveKitAuth,
         full_access_homeservers: Vec<String>,
         app_service_config: AppServiceConfig,
         sanity_check_interval: Duration,
+        membership_check_interval: Duration,
         cs_api_url_overrides: HashMap<String, CsApiUrl>,
         store: Option<Arc<dyn Store>>,
         deps: Arc<dyn Deps>,
@@ -215,17 +252,43 @@ impl Handler {
         let (sfu_event_tx, sfu_event_rx) = mpsc::channel(200);
         let (job_done_tx, job_done_rx) = mpsc::channel(10);
         let (job_restarted_tx, job_restarted_rx) = mpsc::channel(10);
+        let (revoked_tx, revoked_rx) = mpsc::channel(64);
         let (loop_done_tx, _) = watch::channel(false);
         let (recovery_done_tx, _) = watch::channel(false);
 
+        let cancel = CancellationToken::new();
+        let cs_api_url_overrides = Arc::new(cs_api_url_overrides);
+        let cs_api_url_cache = Arc::new(CsApiUrlCache::new());
+
+        let membership_monitor =
+            (app_service_config.is_set_up() && !membership_check_interval.is_zero()).then(|| {
+                MembershipMonitor::new(
+                    &cancel,
+                    MembershipMonitorConfig {
+                        check_interval: membership_check_interval,
+                        hs_server_name: app_service_config.hs_server_name.clone(),
+                        as_token: app_service_config.as_token.clone(),
+                    },
+                    deps.clone(),
+                    lk_auth.clone(),
+                    make_lookup_fn(
+                        deps.clone(),
+                        cs_api_url_overrides.clone(),
+                        cs_api_url_cache.clone(),
+                    ),
+                    store.clone(),
+                    revoked_tx,
+                )
+            });
+
         let handler = Arc::new(Self {
-            cancel: CancellationToken::new(),
+            cancel,
             livekit_auth: lk_auth,
             full_access_homeservers,
             app_service_config,
             sanity_check_interval,
-            cs_api_url_overrides: Arc::new(cs_api_url_overrides),
-            cs_api_url_cache: Arc::new(CsApiUrlCache::new()),
+            cs_api_url_overrides,
+            cs_api_url_cache,
             store,
             deps,
             loop_done_tx,
@@ -234,6 +297,7 @@ impl Handler {
             job_restarted_tx,
             add_job_tx,
             sfu_event_tx,
+            membership_monitor,
         });
         (
             handler,
@@ -242,8 +306,15 @@ impl Handler {
                 sfu_event_rx,
                 job_done_rx,
                 job_restarted_rx,
+                revoked_rx,
             },
         )
+    }
+
+    /// The membership monitor, if enabled.
+    #[cfg(test)]
+    pub(crate) fn membership_monitor(&self) -> Option<&Arc<MembershipMonitor>> {
+        self.membership_monitor.as_ref()
     }
 
     /// A watch receiver that flips to true once start-up recovery completed.
@@ -260,18 +331,11 @@ impl Handler {
     /// Builds a CS-API URL resolver backed by this handler's overrides and
     /// cache.
     fn make_lookup(&self) -> LookupCsApiUrlFn {
-        let deps = self.deps.clone();
-        let overrides = self.cs_api_url_overrides.clone();
-        let cache = self.cs_api_url_cache.clone();
-        Arc::new(move |server_name| {
-            let deps = deps.clone();
-            let overrides = overrides.clone();
-            let cache = cache.clone();
-            Box::pin(async move {
-                deps.resolve_cs_api_url(&server_name, &overrides, Some(&cache))
-                    .await
-            })
-        })
+        make_lookup_fn(
+            self.deps.clone(),
+            self.cs_api_url_overrides.clone(),
+            self.cs_api_url_cache.clone(),
+        )
     }
 
     fn new_job(
@@ -424,7 +488,33 @@ impl Handler {
                             warn!(err = %err, "Handler: job close failed during shutdown");
                         }
                     }
+                    // The monitor shares our cancellation token, so it is
+                    // already shutting down; wait for it to finish.
+                    if let Some(monitor) = &self.membership_monitor {
+                        monitor.close().await;
+                    }
                     break;
+                }
+
+                // ── membership revoked ───────────────────────────────────────
+                Some(key) = rx.revoked_rx.recv() => {
+                    // The participant was removed from the SFU for losing
+                    // their room membership. Their delayed leave event, if
+                    // any, is moot: as a non-member they can no longer send
+                    // it, so tear the job down instead of letting it retry a
+                    // doomed send.
+                    if let Some(job) = jobs.remove(&key) {
+                        info!(room = %key.room, lk_id = %key.identity, job_id = %job.job_id,
+                            "Handler: participant lost room membership, dropping job");
+                        job.stop();
+                        if self.store.is_some() {
+                            enqueue_store_op(StoreOp::Delete {
+                                key,
+                                context: "delete persisted job of revoked participant",
+                            })
+                            .await;
+                        }
+                    }
                 }
 
                 // ── add job ──────────────────────────────────────────────────
@@ -802,6 +892,28 @@ impl Handler {
             })
     }
 
+    /// Registers a freshly minted token with the membership monitor, if
+    /// enabled, so the participant is removed from the SFU should they leave
+    /// (or be kicked or banned from) `matrix_room_id`.
+    async fn track_participant(
+        &self,
+        matrix_room_id: &str,
+        matrix_user_id: &str,
+        lk_room_alias: &LiveKitRoomAlias,
+        lk_identity: &LiveKitIdentity,
+    ) {
+        if let Some(monitor) = &self.membership_monitor {
+            monitor
+                .register(Registration {
+                    matrix_room_id: matrix_room_id.to_owned(),
+                    matrix_user_id: matrix_user_id.to_owned(),
+                    livekit_room: lk_room_alias.clone(),
+                    livekit_identity: lk_identity.clone(),
+                })
+                .await;
+        }
+    }
+
     /// Returns 400 M_INVALID_PARAM if `url` doesn't match this service's
     /// configured LiveKit URL. `endpoint` identifies the call site in the
     /// warning log.
@@ -887,6 +999,9 @@ impl Handler {
             }
         }
 
+        self.track_participant(&req.room, &matrix_id, &lk_room_alias, &lk_identity)
+            .await;
+
         info!(matrix_id = %matrix_id, claimed_device_id = %req.device_id,
             access = if is_full_access_user { "full" } else { "restricted" },
             matrix_room = %req.room, lk_id = %lk_identity, room = %lk_room_alias,
@@ -962,6 +1077,9 @@ impl Handler {
                 .map_err(matrix_error_for_add_job)?;
             }
         }
+
+        self.track_participant(&req.room_id, &matrix_id, &lk_room_alias, &lk_identity)
+            .await;
 
         info!(matrix_id = %matrix_id, claimed_device_id = %req.member.claimed_device_id,
             access = if is_full_access_user { "full" } else { "restricted" },
@@ -1051,6 +1169,9 @@ impl Handler {
 
             self.create_livekit_room_or_internal_error(&lk_room_alias, mxid_header, &lk_identity)
                 .await?;
+
+            self.track_participant(&req.room_id, mxid_header, &lk_room_alias, &lk_identity)
+                .await;
 
             info!(matrix_id = %mxid_header, claimed_device_id = %req.member.claimed_device_id,
                 access = if is_local { "full" } else { "restricted" },
@@ -1159,6 +1280,9 @@ impl Handler {
 
         self.create_livekit_room_or_internal_error(&lk_room_alias, &req.user_id, &lk_identity)
             .await?;
+
+        self.track_participant(&req.room_id, &req.user_id, &lk_room_alias, &lk_identity)
+            .await;
 
         info!(user_id = %req.user_id, claimed_device_id = %req.member.claimed_device_id,
             origin = %origin_header, matrix_room = %req.room_id, matrix_rtc_slot = %req.slot_id,
@@ -1808,6 +1932,30 @@ pub(crate) fn sfu_event_from_webhook(
     }
 }
 
+/// Translates a LiveKit webhook event into the membership monitor's view of
+/// it, if it is one the monitor cares about.
+pub(crate) fn membership_event_from_webhook(
+    event: &livekit_protocol::WebhookEvent,
+) -> Option<SfuEvent> {
+    let room = LiveKitRoomAlias(event.room.as_ref()?.name.clone());
+    let key = |participant: &livekit_protocol::ParticipantInfo| ParticipantKey {
+        room: room.clone(),
+        identity: LiveKitIdentity(participant.identity.clone()),
+    };
+    match event.event.as_str() {
+        "participant_joined" => Some(SfuEvent::ParticipantJoined(key(event
+            .participant
+            .as_ref()?))),
+        "participant_left" | "participant_connection_aborted" => {
+            Some(SfuEvent::ParticipantLeft(key(event
+                .participant
+                .as_ref()?)))
+        }
+        "room_finished" => Some(SfuEvent::RoomFinished(room)),
+        _ => None,
+    }
+}
+
 async fn handle_sfu_webhook(State(handler): State<Arc<Handler>>, req: Request) -> Response {
     let auth_token = req
         .headers()
@@ -1835,6 +1983,14 @@ async fn handle_sfu_webhook(State(handler): State<Arc<Handler>>, req: Request) -
             return StatusCode::OK.into_response();
         }
     };
+
+    // The membership monitor sees every event first: it also cares about
+    // room-level events that carry no participant.
+    if let Some(monitor) = &handler.membership_monitor
+        && let Some(membership_event) = membership_event_from_webhook(&event)
+    {
+        monitor.notify_sfu_event(membership_event).await;
+    }
 
     let Some((room_alias, msg)) = sfu_event_from_webhook(&event) else {
         return StatusCode::OK.into_response();

--- a/src/handler_tests.rs
+++ b/src/handler_tests.rs
@@ -17,10 +17,13 @@ use tower::util::ServiceExt;
 
 use super::*;
 use crate::delayed_event_manager::{AppServiceIdentity, DelayEventAction};
-use crate::helper::{ActionError, RoomServiceClient, UserInfo, resolve_cs_api_url_via};
+use crate::helper::{
+    ActionError, MembershipQueryError, RoomServiceClient, UserInfo, resolve_cs_api_url_via,
+};
 use crate::requests::{GetTokenSsRequest, GetTokenSsResponse, MatrixRtcMemberType};
 use crate::store::test_support::{
     FailingStore, GatedStore, new_in_memory_store, new_notifying_store,
+    new_notifying_store_with_participants,
 };
 
 // ── test deps ─────────────────────────────────────────────────────────────────
@@ -46,6 +49,14 @@ type RequestGetTokenViaFederationFn = Box<
         + Send
         + Sync,
 >;
+type RemoveParticipantFn =
+    Box<dyn Fn(&LiveKitRoomAlias, &LiveKitIdentity) -> Result<(), String> + Send + Sync>;
+type DeleteLiveKitRoomFn = Box<dyn Fn(&LiveKitRoomAlias) -> Result<(), String> + Send + Sync>;
+type GetJoinedMembersFn = Box<
+    dyn Fn(&CsApiUrl, &str) -> Result<std::collections::HashSet<String>, MembershipQueryError>
+        + Send
+        + Sync,
+>;
 
 /// A [`Deps`] implementation with per-test swappable behaviours. Un-mocked
 /// methods panic, except CS-API URL resolution, which falls back to the real
@@ -60,6 +71,9 @@ struct HandlerTestDeps {
     get_delayed_event_delay_fn: Option<GetDelayedEventDelayFn>,
     is_user_joined_fn: Option<IsJoinedFn>,
     request_get_token_via_federation_fn: Option<RequestGetTokenViaFederationFn>,
+    remove_participant_fn: Option<RemoveParticipantFn>,
+    delete_livekit_room_fn: Option<DeleteLiveKitRoomFn>,
+    get_joined_members_fn: Option<GetJoinedMembersFn>,
 }
 
 #[async_trait::async_trait]
@@ -182,6 +196,41 @@ impl Deps for HandlerTestDeps {
             None => panic!("request_get_token_via_federation not mocked in HandlerTestDeps"),
         }
     }
+
+    async fn remove_participant(
+        &self,
+        _lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+        identity: &LiveKitIdentity,
+    ) -> Result<(), String> {
+        match &self.remove_participant_fn {
+            Some(f) => f(room, identity),
+            None => panic!("remove_participant not mocked in HandlerTestDeps"),
+        }
+    }
+
+    async fn delete_livekit_room(
+        &self,
+        _lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+    ) -> Result<(), String> {
+        match &self.delete_livekit_room_fn {
+            Some(f) => f(room),
+            None => panic!("delete_livekit_room not mocked in HandlerTestDeps"),
+        }
+    }
+
+    async fn get_joined_members(
+        &self,
+        cs_api_url: &CsApiUrl,
+        room_id: &str,
+        _as_token: &str,
+    ) -> Result<std::collections::HashSet<String>, MembershipQueryError> {
+        match &self.get_joined_members_fn {
+            Some(f) => f(cs_api_url, room_id),
+            None => panic!("get_joined_members not mocked in HandlerTestDeps"),
+        }
+    }
 }
 
 /// A participant_exists mock that pends until the surrounding job is
@@ -230,6 +279,7 @@ fn new_handler_with(
         full_access.iter().map(|s| s.to_string()).collect(),
         Default::default(),
         Duration::ZERO, // sanity check interval disabled
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         store,
         Arc::new(deps),
@@ -251,6 +301,7 @@ fn new_get_token_handler(deps: HandlerTestDeps) -> Arc<Handler> {
         vec!["example.com".into()],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(deps),
@@ -272,6 +323,7 @@ fn new_get_token_cs_handler(deps: HandlerTestDeps) -> Arc<Handler> {
             hs_server_name: "example.com".into(),
         },
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(deps),
@@ -285,6 +337,7 @@ fn new_delegate_delayed_leave_handler(deps: HandlerTestDeps) -> Arc<Handler> {
         vec!["example.com".into()],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::from([(
             "example.com".to_owned(),
             CsApiUrl("https://matrix.example.com".into()),
@@ -297,7 +350,11 @@ fn new_delegate_delayed_leave_handler(deps: HandlerTestDeps) -> Arc<Handler> {
 /// Creates a Handler configured for testing delegate_delayed_leave C-S requests.
 fn new_delegate_delayed_leave_cs_handler(deps: HandlerTestDeps) -> Arc<Handler> {
     Handler::new(
-        default_auth(),
+        LiveKitAuth {
+            key: "key".into(),
+            secret: "secret".into(),
+            lk_url: LIVEKIT_URL.into(),
+        },
         vec!["example.com".into()],
         crate::config::AppServiceConfig {
             as_token: "as_token".into(),
@@ -305,6 +362,7 @@ fn new_delegate_delayed_leave_cs_handler(deps: HandlerTestDeps) -> Arc<Handler> 
             hs_server_name: "example.com".into(),
         },
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::from([(
             "example.com".to_owned(),
             CsApiUrl("https://matrix.example.com".into()),
@@ -458,6 +516,7 @@ fn new_get_token_ss_handler(deps: HandlerTestDeps) -> Arc<Handler> {
             hs_server_name: "example.com".into(),
         },
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(deps),
@@ -497,7 +556,7 @@ const DELEGATE_DELAYED_LEAVE_CS_MXID: &str = "@user:example.com";
 /// A fully populated, valid delegate_delayed_leave C-S request.
 fn valid_delegate_delayed_leave_cs_request() -> DelegateDelayedLeaveCsRequest {
     DelegateDelayedLeaveCsRequest {
-        url: default_auth().lk_url,
+        url: LIVEKIT_URL.into(),
         room_id: "!testRoom:example.com".into(),
         slot_id: "m.call#ROOM".into(),
         member: MatrixRtcMemberType {
@@ -573,6 +632,7 @@ async fn test_is_full_access_user() {
         vec!["example.com".into(), "another.example.com".into()],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(HandlerTestDeps::default()),
@@ -770,6 +830,7 @@ async fn test_handler_close_timeout() {
         vec!["*".into()],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(HandlerTestDeps::default()),
@@ -983,6 +1044,7 @@ fn new_sfu_webhook_test_handler(key: &str, secret: &str) -> (Arc<Handler>, LoopR
         vec![],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         None,
         Arc::new(HandlerTestDeps::default()),
@@ -2097,6 +2159,7 @@ async fn test_process_sfu_request() {
             vec!["example.com".into()],
             Default::default(),
             Duration::ZERO,
+            Duration::ZERO, // membership check disabled
             HashMap::new(),
             None,
             Arc::new(deps),
@@ -2810,6 +2873,7 @@ async fn test_process_get_token_cs_request() {
                 hs_server_name: "example.com".into(),
             },
             Duration::ZERO,
+            Duration::ZERO, // membership check disabled
             HashMap::new(),
             None,
             Arc::new(deps),
@@ -3277,6 +3341,7 @@ async fn test_process_get_token_ss_request() {
                 hs_server_name: OWN_SERVER.into(),
             },
             Duration::ZERO,
+            Duration::ZERO, // membership check disabled
             HashMap::new(),
             None,
             Arc::new(deps),
@@ -3396,6 +3461,7 @@ async fn test_handle_sfu_get_success() {
         vec![MATRIX_SERVER_NAME.into()],
         Default::default(),
         Duration::ZERO,
+        Duration::ZERO, // membership check disabled
         HashMap::new(),
         Some(new_in_memory_store()),
         Arc::new(deps),
@@ -3546,6 +3612,7 @@ async fn test_process_legacy_sfu_request() {
             vec!["example.com".into()],
             Default::default(),
             Duration::ZERO,
+            Duration::ZERO, // membership check disabled
             HashMap::new(),
             Some(new_in_memory_store()),
             Arc::new(deps),
@@ -4388,4 +4455,379 @@ async fn test_process_delegate_delayed_leave_cs_delay_lookup_unavailable() {
     assert_eq!(err.status, 503, "expected 503");
     assert_eq!(err.errcode, "M_UNKNOWN", "expected M_UNKNOWN");
     handler.close().await;
+}
+
+// ── membership monitor wiring ─────────────────────────────────────────────────
+// The monitor's own behaviour is covered in membership_monitor_tests.rs. These
+// tests cover how the handler feeds it: which endpoints register participants,
+// how SFU webhooks reach it, and what happens to a delayed-event job once the
+// monitor removes its participant.
+
+/// A monitor check interval long enough never to fire during a test; sweeps
+/// are triggered explicitly.
+const NEVER: Duration = Duration::from_secs(60 * 60);
+
+/// The application service configuration the membership tests run with.
+fn membership_app_service_config() -> crate::config::AppServiceConfig {
+    crate::config::AppServiceConfig {
+        as_token: "as_token".into(),
+        hs_token: HS_TOKEN.into(),
+        hs_server_name: "example.com".into(),
+    }
+}
+
+/// Creates a Handler running as an application service with the membership
+/// monitor enabled, example.com as the only full-access homeserver and a
+/// CS-API override for it.
+fn new_membership_handler(deps: HandlerTestDeps, store: Option<Arc<dyn Store>>) -> Arc<Handler> {
+    Handler::new(
+        LiveKitAuth {
+            key: "key".into(),
+            secret: "secret".into(),
+            lk_url: LIVEKIT_URL.into(),
+        },
+        vec!["example.com".into()],
+        membership_app_service_config(),
+        Duration::ZERO,
+        NEVER,
+        HashMap::from([(
+            "example.com".to_owned(),
+            CsApiUrl("https://matrix.example.com".into()),
+        )]),
+        store,
+        Arc::new(deps),
+    )
+}
+
+/// The deps a successful C-S /get_token needs.
+fn get_token_cs_deps() -> HandlerTestDeps {
+    HandlerTestDeps {
+        is_user_joined_fn: is_joined_ok(true),
+        create_livekit_room_fn: Some(Box::new(|_, _, _| Ok(()))),
+        ..Default::default()
+    }
+}
+
+/// The one participant the monitor tracks, or a panic.
+async fn sole_tracked_participant(
+    handler: &Arc<Handler>,
+) -> crate::membership_monitor::TrackedParticipant {
+    let snapshot = handler
+        .membership_monitor()
+        .expect("expected the membership monitor to be enabled")
+        .snapshot()
+        .await;
+    assert_eq!(
+        snapshot.len(),
+        1,
+        "expected exactly one tracked participant, got {snapshot:?}"
+    );
+    snapshot.into_iter().next().unwrap()
+}
+
+/// Without an application service configuration there is nothing to query
+/// membership with, so no monitor is created however the interval is set.
+#[tokio::test]
+async fn test_membership_monitor_requires_app_service_config() {
+    let handler = Handler::new(
+        default_auth(),
+        vec!["example.com".into()],
+        Default::default(),
+        Duration::ZERO,
+        NEVER,
+        HashMap::new(),
+        None,
+        Arc::new(HandlerTestDeps::default()),
+    );
+    assert!(handler.membership_monitor().is_none());
+    handler.close().await;
+}
+
+/// A zero check interval disables the monitor.
+#[tokio::test]
+async fn test_membership_monitor_disabled_by_zero_interval() {
+    let handler = new_get_token_cs_handler(HandlerTestDeps::default());
+    assert!(handler.membership_monitor().is_none());
+    handler.close().await;
+}
+
+/// A locally minted C-S token registers the participant with the Matrix room
+/// and user it was issued for, as pending until the SFU reports them.
+#[tokio::test]
+async fn test_get_token_cs_registers_participant() {
+    let handler = new_membership_handler(get_token_cs_deps(), None);
+
+    let body = marshal_get_token_cs_request(|_| {});
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let tracked = sole_tracked_participant(&handler).await;
+    assert_eq!(tracked.stored.matrix_room_id, "!testRoom:example.com");
+    assert_eq!(tracked.stored.matrix_user_id, GET_TOKEN_CS_MXID);
+    assert_eq!(
+        tracked.stored.livekit_room,
+        livekit_room_alias_for("!testRoom:example.com", "m.call#ROOM")
+    );
+    assert_eq!(
+        tracked.stored.livekit_identity,
+        livekit_identity_for(GET_TOKEN_CS_MXID, "device-id", "member-id")
+    );
+    assert!(!tracked.connected);
+    handler.close().await;
+}
+
+/// A token relayed from another homeserver was minted there, not here, so
+/// there is nothing to track locally.
+#[tokio::test]
+async fn test_get_token_cs_relay_does_not_register() {
+    let deps = HandlerTestDeps {
+        is_user_joined_fn: is_joined_ok(true),
+        request_get_token_via_federation_fn: request_get_token_via_federation_ok("remote-jwt"),
+        ..Default::default()
+    };
+    let handler = new_membership_handler(deps, None);
+
+    let body = marshal_get_token_cs_request(|r| {
+        r.server_name = "other.example.org".into();
+        r.url = "wss://sfu.other.example.org".into();
+    });
+    let resp = send_request(&handler, post_get_token_cs_request(body, GET_TOKEN_CS_MXID)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(
+        handler
+            .membership_monitor()
+            .unwrap()
+            .snapshot()
+            .await
+            .is_empty()
+    );
+    handler.close().await;
+}
+
+/// A token minted for a federated participant via the S-S endpoint is
+/// tracked against the requesting remote user.
+#[tokio::test]
+async fn test_get_token_ss_registers_participant() {
+    let deps = HandlerTestDeps {
+        is_user_joined_fn: is_joined_ok(true),
+        create_livekit_room_fn: Some(Box::new(|_, _, _| Ok(()))),
+        ..Default::default()
+    };
+    let handler = new_membership_handler(deps, None);
+
+    let body = marshal_get_token_ss_request(|_| {});
+    let resp = send_request(
+        &handler,
+        post_get_token_ss_request(body, GET_TOKEN_SS_ORIGIN),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let tracked = sole_tracked_participant(&handler).await;
+    assert_eq!(tracked.stored.matrix_room_id, "!testRoom:example.com");
+    assert_eq!(tracked.stored.matrix_user_id, "@user:origin.example.org");
+    assert_eq!(
+        tracked.stored.livekit_identity,
+        livekit_identity_for("@user:origin.example.org", "device-id", "member-id")
+    );
+    handler.close().await;
+}
+
+/// The OpenID-authenticated /get_token endpoint registers participants too.
+#[tokio::test]
+async fn test_get_token_registers_participant() {
+    let deps = HandlerTestDeps {
+        exchange_openid_userinfo_fn: exchange_openid_userinfo_ok("@user:example.com"),
+        create_livekit_room_fn: Some(Box::new(|_, _, _| Ok(()))),
+        ..Default::default()
+    };
+    let handler = new_membership_handler(deps, None);
+
+    let body = marshal_sfu_request(|r| r.openid_token.matrix_server_name = "example.com".into());
+    let resp = send_request(&handler, post_json("/get_token", body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let tracked = sole_tracked_participant(&handler).await;
+    assert_eq!(tracked.stored.matrix_room_id, "!testRoom:example.com");
+    assert_eq!(tracked.stored.matrix_user_id, "@user:example.com");
+    assert_eq!(
+        tracked.stored.livekit_identity,
+        livekit_identity_for("@user:example.com", "device-id", "member-id")
+    );
+    handler.close().await;
+}
+
+/// The deprecated /sfu/get endpoint registers participants under its legacy
+/// identity scheme.
+#[tokio::test]
+async fn test_legacy_sfu_get_registers_participant() {
+    let deps = HandlerTestDeps {
+        exchange_openid_userinfo_fn: exchange_openid_userinfo_ok("@user:example.com"),
+        create_livekit_room_fn: Some(Box::new(|_, _, _| Ok(()))),
+        ..Default::default()
+    };
+    let handler = new_membership_handler(deps, None);
+
+    let body = serde_json::json!({
+        "room": "!testRoom:example.com",
+        "openid_token": {
+            "access_token": "test-token",
+            "matrix_server_name": "example.com",
+        },
+        "device_id": "device-id",
+    });
+    let resp = send_request(&handler, post_json("/sfu/get", body.to_string())).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let tracked = sole_tracked_participant(&handler).await;
+    assert_eq!(tracked.stored.matrix_room_id, "!testRoom:example.com");
+    assert_eq!(tracked.stored.matrix_user_id, "@user:example.com");
+    assert_eq!(
+        tracked.stored.livekit_room,
+        livekit_room_alias_for("!testRoom:example.com", "m.call#ROOM")
+    );
+    assert_eq!(
+        tracked.stored.livekit_identity,
+        LiveKitIdentity("@user:example.com:device-id".into())
+    );
+    handler.close().await;
+}
+
+/// SFU webhooks reach the monitor: a join marks the participant connected, a
+/// leave forgets them, and a finished room forgets everyone in it.
+#[tokio::test]
+async fn test_sfu_webhook_feeds_membership_monitor() {
+    let handler = new_membership_handler(get_token_cs_deps(), None);
+    let monitor = handler.membership_monitor().unwrap().clone();
+    let room = livekit_room_alias_for("!testRoom:example.com", "m.call#ROOM");
+    let identity = livekit_identity_for(GET_TOKEN_CS_MXID, "device-id", "member-id");
+    let webhook = |event: &str, participant: bool| {
+        let event = livekit_protocol::WebhookEvent {
+            event: event.into(),
+            room: Some(livekit_protocol::Room {
+                name: room.0.clone(),
+                ..Default::default()
+            }),
+            participant: participant.then(|| livekit_protocol::ParticipantInfo {
+                identity: identity.0.clone(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        signed_sfu_webhook_request("key", "secret", &event)
+    };
+    let mint =
+        || post_get_token_cs_request(marshal_get_token_cs_request(|_| {}), GET_TOKEN_CS_MXID);
+
+    // Join.
+    assert_eq!(
+        send_request(&handler, mint()).await.status(),
+        StatusCode::OK
+    );
+    assert!(!sole_tracked_participant(&handler).await.connected);
+    send_request(&handler, webhook("participant_joined", true)).await;
+    assert!(sole_tracked_participant(&handler).await.connected);
+
+    // Leave.
+    send_request(&handler, webhook("participant_left", true)).await;
+    assert!(monitor.snapshot().await.is_empty());
+
+    // Room finished.
+    assert_eq!(
+        send_request(&handler, mint()).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(monitor.snapshot().await.len(), 1);
+    send_request(&handler, webhook("room_finished", false)).await;
+    assert!(monitor.snapshot().await.is_empty());
+
+    handler.close().await;
+}
+
+/// Once the monitor removes a participant for losing their room membership,
+/// the handler drops that participant's delayed-event job — from the loop
+/// and from the store — instead of letting it attempt a send the homeserver
+/// would refuse.
+#[tokio::test]
+async fn test_revoked_participant_drops_delayed_event_job() {
+    let (store, mut job_saved_rx, mut job_deleted_rx, mut participants) =
+        new_notifying_store_with_participants();
+    let removed: Arc<Mutex<Vec<ParticipantKey>>> = Arc::new(Mutex::new(Vec::new()));
+    let removed_clone = removed.clone();
+    let deps = HandlerTestDeps {
+        is_user_joined_fn: is_joined_ok(true),
+        create_livekit_room_fn: Some(Box::new(|_, _, _| Ok(()))),
+        // The job's participant lookup and restarts.
+        participant_exists_fn: Some(Box::new(|_, _| Box::pin(async { Ok(true) }))),
+        execute_delayed_event_action_fn: execute_delayed_event_action_ok(),
+        // The monitor: the user is gone from the room.
+        get_joined_members_fn: Some(Box::new(|_, _| Ok(std::collections::HashSet::new()))),
+        remove_participant_fn: Some(Box::new(move |room, identity| {
+            removed_clone.lock().unwrap().push(ParticipantKey {
+                room: room.clone(),
+                identity: identity.clone(),
+            });
+            Ok(())
+        })),
+        ..Default::default()
+    };
+    let handler = new_membership_handler(deps, Some(store));
+    let monitor = handler.membership_monitor().unwrap().clone();
+    let key = ParticipantKey {
+        room: livekit_room_alias_for("!testRoom:example.com", "m.call#ROOM"),
+        identity: livekit_identity_for(GET_TOKEN_CS_MXID, "device-id", "member-id"),
+    };
+
+    // Mint a token and delegate a delayed leave for the same participant.
+    let resp = send_request(
+        &handler,
+        post_get_token_cs_request(marshal_get_token_cs_request(|_| {}), GET_TOKEN_CS_MXID),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = send_request(
+        &handler,
+        post_delegate_delayed_leave_cs_request(
+            marshal_delegate_delayed_leave_cs_request(|_| {}),
+            DELEGATE_DELAYED_LEAVE_CS_MXID,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), job_saved_rx.recv())
+            .await
+            .expect("timed out waiting for the job to be stored"),
+        Some(key.clone())
+    );
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), participants.saved_rx.recv())
+            .await
+            .expect("timed out waiting for the participant to be stored"),
+        Some(key.clone())
+    );
+
+    // The participant connects, then the monitor finds them gone from the
+    // room.
+    monitor
+        .notify_sfu_event(SfuEvent::ParticipantJoined(key.clone()))
+        .await;
+    monitor.sweep_now().await;
+
+    // The job is gone from the store — and so is the participant.
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), job_deleted_rx.recv())
+            .await
+            .expect("timed out waiting for the job to be deleted"),
+        Some(key.clone())
+    );
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), participants.deleted_rx.recv())
+            .await
+            .expect("timed out waiting for the participant to be deleted"),
+        Some(key.clone())
+    );
+    handler.close().await;
+    assert_eq!(removed.lock().unwrap().as_slice(), [key]);
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -7,7 +7,7 @@
 //! service calls and Matrix CS-API calls. External interactions live behind
 //! the [`Deps`] trait so they can be replaced in tests.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -112,6 +112,15 @@ string_newtype!(LiveKitRoomAlias);
 string_newtype!(LiveKitIdentity);
 string_newtype!(CsApiUrl);
 string_newtype!(UniqueId);
+
+/// Identifies one participant on the SFU: the LiveKit room they are in and
+/// their LiveKit identity. Identities are derived from the Matrix user ID
+/// (which includes the homeserver domain), so the pair is globally unique.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ParticipantKey {
+    pub room: LiveKitRoomAlias,
+    pub identity: LiveKitIdentity,
+}
 
 /// Generates a unique ID: an 8-byte big-endian microsecond timestamp
 /// followed by 8 random bytes, Base32Hex-encoded without padding. The
@@ -275,6 +284,13 @@ pub enum RoomServiceError {
 pub trait RoomServiceClient: Send + Sync {
     async fn create_room(&self, params: CreateRoomParams) -> Result<RoomInfo, RoomServiceError>;
     async fn get_participant(&self, room: &str, identity: &str) -> Result<(), RoomServiceError>;
+    /// Disconnects the participant `identity` from `room`. Fails with
+    /// [`RoomServiceError::NotFound`] when the participant (or the room) is
+    /// not present.
+    async fn remove_participant(&self, room: &str, identity: &str) -> Result<(), RoomServiceError>;
+    /// Deletes `room`, disconnecting every participant in it. Fails with
+    /// [`RoomServiceError::NotFound`] when the room does not exist.
+    async fn delete_room(&self, room: &str) -> Result<(), RoomServiceError>;
 }
 
 /// Converts a LiveKit URL to its HTTP form: ws:// becomes http://, wss://
@@ -421,6 +437,41 @@ impl RoomServiceClient for LiveKitRoomServiceClient {
             .await?;
         Ok(())
     }
+
+    async fn remove_participant(&self, room: &str, identity: &str) -> Result<(), RoomServiceError> {
+        let _: livekit_protocol::RemoveParticipantResponse = self
+            .twirp_call(
+                "RemoveParticipant",
+                livekit_api::access_token::VideoGrants {
+                    room_admin: true,
+                    room: room.to_owned(),
+                    ..Default::default()
+                },
+                livekit_protocol::RoomParticipantIdentity {
+                    room: room.to_owned(),
+                    identity: identity.to_owned(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_room(&self, room: &str) -> Result<(), RoomServiceError> {
+        let _: livekit_protocol::DeleteRoomResponse = self
+            .twirp_call(
+                "DeleteRoom",
+                livekit_api::access_token::VideoGrants {
+                    room_create: true,
+                    ..Default::default()
+                },
+                livekit_protocol::DeleteRoomRequest {
+                    room: room.to_owned(),
+                },
+            )
+            .await?;
+        Ok(())
+    }
 }
 
 // ── delayed-event action error taxonomy ──────────────────────────────────────
@@ -516,6 +567,36 @@ async fn retry_after_from_response(resp: reqwest::Response, status: u16) -> Acti
         status,
         msg: "CS API temporarily unavailable (http status code 429)".into(),
     }
+}
+
+/// The subject of an `/is_joined` query (MSC4502): either a specific Matrix
+/// user ID or a server name.
+pub enum IsJoinedSubject<'a> {
+    Mxid(&'a str),
+    ServerName(&'a str),
+}
+
+impl IsJoinedSubject<'_> {
+    /// The `(query parameter name, value)` pair to send for this subject.
+    fn query(&self) -> (&'static str, &str) {
+        match self {
+            IsJoinedSubject::Mxid(mxid) => ("mxid", mxid),
+            IsJoinedSubject::ServerName(server_name) => ("server_name", server_name),
+        }
+    }
+}
+
+/// The error side of [`Deps::get_joined_members`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MembershipQueryError {
+    /// The homeserver refused the query (HTTP 403): none of the application
+    /// service's users is joined to the room. With a local-only user
+    /// namespace this means the homeserver itself is no longer in the room.
+    #[error("no application service user is joined to the room")]
+    NotInRoom,
+    /// Transport, server or decoding failure — membership unknown.
+    #[error("{0}")]
+    Other(String),
 }
 
 /// The outcome of a failed `/get_token` federation relay: either the
@@ -711,6 +792,109 @@ pub trait Deps: Send + Sync {
             Err(RoomServiceError::NotFound(_)) => Ok(false),
             Err(err) => Err(err.to_string()),
         }
+    }
+
+    /// Disconnects the given identity from the given LiveKit room. A
+    /// participant that is (no longer) present is not an error: the desired
+    /// end state — the identity being gone from the room — already holds.
+    async fn remove_participant(
+        &self,
+        lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+        identity: &LiveKitIdentity,
+    ) -> Result<(), String> {
+        let room_client =
+            self.new_room_service_client(&lk_auth.lk_url, &lk_auth.key, &lk_auth.secret);
+        match room_client.remove_participant(&room.0, &identity.0).await {
+            Ok(()) | Err(RoomServiceError::NotFound(_)) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    /// Deletes the given LiveKit room, disconnecting everyone in it. A room
+    /// that does not exist is not an error, for the same reason as in
+    /// [`Deps::remove_participant`].
+    async fn delete_livekit_room(
+        &self,
+        lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+    ) -> Result<(), String> {
+        let room_client =
+            self.new_room_service_client(&lk_auth.lk_url, &lk_auth.key, &lk_auth.secret);
+        match room_client.delete_room(&room.0).await {
+            Ok(()) | Err(RoomServiceError::NotFound(_)) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    /// Fetches the set of users currently joined to `room_id` via
+    /// `GET /rooms/{roomId}/joined_members`, authenticated as the application
+    /// service itself.
+    ///
+    /// The endpoint is served to an application service as long as one of the
+    /// users in its namespace is joined to the room. With a namespace covering
+    /// this homeserver's local users, a 403 therefore means the homeserver has
+    /// no local user in the room any more, which callers see as
+    /// [`MembershipQueryError::NotInRoom`].
+    async fn get_joined_members(
+        &self,
+        cs_api_url: &CsApiUrl,
+        room_id: &str,
+        as_token: &str,
+    ) -> Result<HashSet<String>, MembershipQueryError> {
+        let mut endpoint = url::Url::parse(cs_api_url.as_str()).map_err(|e| {
+            MembershipQueryError::Other(format!("invalid client-server API URL: {e}"))
+        })?;
+        {
+            let mut segments = endpoint.path_segments_mut().map_err(|_| {
+                MembershipQueryError::Other(
+                    "invalid client-server API URL: cannot be a base".into(),
+                )
+            })?;
+            segments.pop_if_empty();
+            segments.extend([
+                "_matrix",
+                "client",
+                "v3",
+                "rooms",
+                room_id,
+                "joined_members",
+            ]);
+        }
+
+        let resp = http_client(self.skip_verify_tls())
+            .get(endpoint.clone())
+            .bearer_auth(as_token)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| {
+                let msg = error_chain(&e);
+                debug!(url = %endpoint, err = %msg, "get_joined_members");
+                MembershipQueryError::Other(format!("failed to fetch joined members: {msg}"))
+            })?;
+
+        let status = resp.status();
+        debug!(url = %endpoint, status = status.as_u16(), "get_joined_members");
+        if status == http::StatusCode::FORBIDDEN {
+            return Err(MembershipQueryError::NotInRoom);
+        }
+        if !status.is_success() {
+            return Err(MembershipQueryError::Other(format!(
+                "failed to fetch joined members: http status code {}",
+                status.as_u16()
+            )));
+        }
+
+        #[derive(Deserialize, Default)]
+        struct JoinedMembersResponse {
+            #[serde(default)]
+            joined: HashMap<String, serde_json::Value>,
+        }
+        let parsed: JoinedMembersResponse = resp.json().await.map_err(|e| {
+            MembershipQueryError::Other(format!("failed to parse joined_members response: {e}"))
+        })?;
+        Ok(parsed.joined.into_keys().collect())
     }
 
     /// GETs the delay of the delayed event identified by `delay_id` from the C-S API,
@@ -925,6 +1109,37 @@ pub trait Deps: Send + Sync {
         mxid: &str,
         as_token: &str,
     ) -> Result<bool, String> {
+        self.check_is_joined(cs_api_url, room_id, IsJoinedSubject::Mxid(mxid), as_token)
+            .await
+    }
+
+    /// Checks whether `server_name` is currently joined to `room_id`, via the
+    /// `/is_joined` endpoint from MSC4502.
+    async fn is_server_joined(
+        &self,
+        cs_api_url: &CsApiUrl,
+        room_id: &str,
+        server_name: &str,
+        as_token: &str,
+    ) -> Result<bool, String> {
+        self.check_is_joined(
+            cs_api_url,
+            room_id,
+            IsJoinedSubject::ServerName(server_name),
+            as_token,
+        )
+        .await
+    }
+
+    /// Performs a room membership check for an MXID or server name, via the
+    /// `/is_joined` endpoint from MSC4502.
+    async fn check_is_joined(
+        &self,
+        cs_api_url: &CsApiUrl,
+        room_id: &str,
+        subject: IsJoinedSubject<'_>,
+        as_token: &str,
+    ) -> Result<bool, String> {
         const IS_JOINED_PATH_PREFIX: &str = "_matrix/client/unstable/io.element.msc4502";
 
         let mut endpoint = url::Url::parse(cs_api_url.as_str())
@@ -941,7 +1156,10 @@ pub trait Deps: Send + Sync {
             segments.push(room_id);
             segments.push("is_joined");
         }
-        endpoint.query_pairs_mut().append_pair("mxid", mxid);
+        let (query_param, query_value) = subject.query();
+        endpoint
+            .query_pairs_mut()
+            .append_pair(query_param, query_value);
 
         let resp = http_client(self.skip_verify_tls())
             .get(endpoint.clone())
@@ -951,7 +1169,7 @@ pub trait Deps: Send + Sync {
             .await
             .map_err(|e| {
                 let msg = error_chain(&e);
-                debug!(url = %endpoint, err = %msg, "is_user_joined");
+                debug!(url = %endpoint, err = %msg, "check_is_joined");
                 format!("failed to check room membership: {msg}")
             })?;
 
@@ -2533,6 +2751,195 @@ mod tests {
         );
     }
 
+    // ── is_server_joined ─────────────────────────────────────────────────────
+
+    /// The request is shaped correctly: it uses `server_name`, not `mxid`.
+    #[tokio::test]
+    async fn test_is_server_joined_request_shape() {
+        let hs = spawn_is_joined_server(true).await;
+
+        let _ = RealDeps::default()
+            .is_server_joined(
+                &CsApiUrl(hs.server.url.clone()),
+                "!room:example.com",
+                "origin.example.org",
+                "the_as_token",
+            )
+            .await
+            .expect("unexpected error");
+
+        let requests = hs.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let (uri, headers) = &requests[0];
+        assert!(
+            uri.contains("server_name=origin.example.org"),
+            "expected a server_name query param, got {uri:?}"
+        );
+        assert!(
+            !uri.contains("mxid="),
+            "expected no mxid query param, got {uri:?}"
+        );
+        assert_eq!(
+            headers
+                .get(http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer the_as_token"),
+        );
+    }
+
+    // ── get_joined_members ───────────────────────────────────────────────────
+
+    /// A homeserver stub serving /joined_members with a canned status and
+    /// body, recording every request's URI and headers.
+    async fn spawn_joined_members_server(
+        status: http::StatusCode,
+        body: serde_json::Value,
+    ) -> IsJoinedServer {
+        let requests: Arc<Mutex<Vec<(String, http::HeaderMap)>>> = Arc::new(Mutex::new(Vec::new()));
+        let requests_clone = requests.clone();
+        let router = Router::new().route(
+            "/_matrix/client/v3/rooms/{room_id}/joined_members",
+            any(move |req: Request| {
+                let requests = requests_clone.clone();
+                let body = body.clone();
+                async move {
+                    requests
+                        .lock()
+                        .unwrap()
+                        .push((req.uri().to_string(), req.headers().clone()));
+                    (status, axum::Json(body))
+                }
+            }),
+        );
+        let server = spawn_http_server(router).await;
+        IsJoinedServer { server, requests }
+    }
+
+    /// The request is shaped correctly — stable v3 path with the room ID,
+    /// application-service token, no identity assertion — and the response
+    /// is reduced to the set of joined user IDs.
+    #[tokio::test]
+    async fn test_get_joined_members_request_shape_and_parsing() {
+        let hs = spawn_joined_members_server(
+            http::StatusCode::OK,
+            serde_json::json!({
+                "joined": {
+                    "@alice:example.com": {"display_name": "Alice", "avatar_url": null},
+                    "@bob:remote.example.org": {},
+                }
+            }),
+        )
+        .await;
+
+        let members = RealDeps::default()
+            .get_joined_members(
+                &CsApiUrl(hs.server.url.clone()),
+                "!room:example.com",
+                "the_as_token",
+            )
+            .await
+            .expect("unexpected error");
+        assert_eq!(
+            members,
+            HashSet::from([
+                "@alice:example.com".to_owned(),
+                "@bob:remote.example.org".to_owned()
+            ])
+        );
+
+        let requests = hs.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let (uri, headers) = &requests[0];
+        assert!(
+            uri.starts_with("/_matrix/client/v3/rooms/")
+                && uri.ends_with("/joined_members")
+                && (uri.contains("%21room%3Aexample.com") || uri.contains("!room:example.com")),
+            "unexpected request URI {uri:?}"
+        );
+        assert!(
+            !uri.contains("user_id="),
+            "expected no identity assertion, got {uri:?}"
+        );
+        assert_eq!(
+            headers
+                .get(http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer the_as_token"),
+        );
+    }
+
+    /// A 403 means no application-service user is in the room.
+    #[tokio::test]
+    async fn test_get_joined_members_forbidden_is_not_in_room() {
+        let hs = spawn_joined_members_server(
+            http::StatusCode::FORBIDDEN,
+            serde_json::json!({"errcode": "M_FORBIDDEN", "error": "Appservice not in room"}),
+        )
+        .await;
+
+        let err = RealDeps::default()
+            .get_joined_members(
+                &CsApiUrl(hs.server.url.clone()),
+                "!room:example.com",
+                "the_as_token",
+            )
+            .await
+            .expect_err("expected an error");
+        assert_eq!(err, MembershipQueryError::NotInRoom);
+    }
+
+    /// Any other failure is reported as such, not as a membership fact.
+    #[tokio::test]
+    async fn test_get_joined_members_other_errors() {
+        let hs = spawn_joined_members_server(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            serde_json::json!({"errcode": "M_UNKNOWN"}),
+        )
+        .await;
+        let err = RealDeps::default()
+            .get_joined_members(
+                &CsApiUrl(hs.server.url.clone()),
+                "!room:example.com",
+                "the_as_token",
+            )
+            .await
+            .expect_err("expected an error");
+        assert!(
+            matches!(&err, MembershipQueryError::Other(msg) if msg.contains("500")),
+            "unexpected error: {err:?}"
+        );
+
+        // An unparseable success body is an error as well.
+        let hs =
+            spawn_joined_members_server(http::StatusCode::OK, serde_json::json!([1, 2, 3])).await;
+        let err = RealDeps::default()
+            .get_joined_members(
+                &CsApiUrl(hs.server.url.clone()),
+                "!room:example.com",
+                "the_as_token",
+            )
+            .await
+            .expect_err("expected an error");
+        assert!(
+            matches!(err, MembershipQueryError::Other(_)),
+            "unexpected error: {err:?}"
+        );
+
+        // As is an unreachable homeserver.
+        let err = RealDeps::default()
+            .get_joined_members(
+                &CsApiUrl("http://127.0.0.1:9".into()),
+                "!room:example.com",
+                "the_as_token",
+            )
+            .await
+            .expect_err("expected an error");
+        assert!(
+            matches!(err, MembershipQueryError::Other(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
     // ── resolve_cs_api_url ────────────────────────────────────────────────────
 
     /// A Deps implementation with a swappable discover_client_api.
@@ -2744,11 +3151,16 @@ mod tests {
     type CreateRoomFn =
         Box<dyn Fn(CreateRoomParams) -> Result<RoomInfo, RoomServiceError> + Send + Sync>;
     type GetParticipantFn = Box<dyn Fn(&str, &str) -> Result<(), RoomServiceError> + Send + Sync>;
+    type RemoveParticipantFn =
+        Box<dyn Fn(&str, &str) -> Result<(), RoomServiceError> + Send + Sync>;
+    type DeleteRoomFn = Box<dyn Fn(&str) -> Result<(), RoomServiceError> + Send + Sync>;
 
     #[derive(Default)]
     struct MockRoomServiceClient {
         create_room_fn: Option<CreateRoomFn>,
         get_participant_fn: Option<GetParticipantFn>,
+        remove_participant_fn: Option<RemoveParticipantFn>,
+        delete_room_fn: Option<DeleteRoomFn>,
     }
 
     #[async_trait]
@@ -2770,6 +3182,24 @@ mod tests {
         ) -> Result<(), RoomServiceError> {
             match &self.get_participant_fn {
                 Some(f) => f(room, identity),
+                None => Ok(()),
+            }
+        }
+
+        async fn remove_participant(
+            &self,
+            room: &str,
+            identity: &str,
+        ) -> Result<(), RoomServiceError> {
+            match &self.remove_participant_fn {
+                Some(f) => f(room, identity),
+                None => Ok(()),
+            }
+        }
+
+        async fn delete_room(&self, room: &str) -> Result<(), RoomServiceError> {
+            match &self.delete_room_fn {
+                Some(f) => f(room),
                 None => Ok(()),
             }
         }
@@ -2818,7 +3248,7 @@ mod tests {
                         creation_time: creation_start + 1,
                     })
                 })),
-                get_participant_fn: None,
+                ..Default::default()
             }),
         };
 
@@ -2847,7 +3277,7 @@ mod tests {
                         creation_time: creation_start - 100,
                     })
                 })),
-                get_participant_fn: None,
+                ..Default::default()
             }),
         };
 
@@ -2877,7 +3307,7 @@ mod tests {
                 create_room_fn: Some(Box::new(|_| {
                     Err(RoomServiceError::Other("SDK connection failed".into()))
                 })),
-                get_participant_fn: None,
+                ..Default::default()
             }),
         };
 
@@ -2916,7 +3346,7 @@ mod tests {
                         creation_time: unix_now(),
                     })
                 })),
-                get_participant_fn: None,
+                ..Default::default()
             }),
         };
 
@@ -2953,7 +3383,6 @@ mod tests {
         let calls_clone = calls.clone();
         let deps = RoomClientMockDeps {
             client: Arc::new(MockRoomServiceClient {
-                create_room_fn: None,
                 get_participant_fn: Some(Box::new(move |_, _| {
                     match calls_clone.fetch_add(1, Ordering::SeqCst) {
                         0 => Ok(()),
@@ -2961,6 +3390,7 @@ mod tests {
                         _ => Err(RoomServiceError::Other("boom".into())),
                     }
                 })),
+                ..Default::default()
             }),
         };
 
@@ -2980,6 +3410,89 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    // ── remove_participant / delete_livekit_room via mocked room client ───────
+
+    /// A participant that is already gone counts as removed; any other
+    /// failure surfaces.
+    #[tokio::test]
+    async fn test_remove_participant_contract() {
+        let auth = LiveKitAuth::default();
+        let room = LiveKitRoomAlias("room".into());
+        let identity = LiveKitIdentity("id".into());
+
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let seen: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = seen.clone();
+        let deps = RoomClientMockDeps {
+            client: Arc::new(MockRoomServiceClient {
+                remove_participant_fn: Some(Box::new(move |room, identity| {
+                    seen_clone
+                        .lock()
+                        .unwrap()
+                        .push((room.to_owned(), identity.to_owned()));
+                    match calls_clone.fetch_add(1, Ordering::SeqCst) {
+                        0 => Ok(()),
+                        1 => Err(RoomServiceError::NotFound("not found".into())),
+                        _ => Err(RoomServiceError::Other("boom".into())),
+                    }
+                })),
+                ..Default::default()
+            }),
+        };
+
+        deps.remove_participant(&auth, &room, &identity)
+            .await
+            .expect("removal should succeed");
+        deps.remove_participant(&auth, &room, &identity)
+            .await
+            .expect("removing an absent participant should succeed");
+        deps.remove_participant(&auth, &room, &identity)
+            .await
+            .expect_err("other errors should surface");
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 3);
+        assert!(
+            seen.iter().all(|(r, i)| r == "room" && i == "id"),
+            "unexpected arguments: {seen:?}"
+        );
+    }
+
+    /// A room that does not exist counts as deleted; any other failure
+    /// surfaces.
+    #[tokio::test]
+    async fn test_delete_livekit_room_contract() {
+        let auth = LiveKitAuth::default();
+        let room = LiveKitRoomAlias("room".into());
+
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let deps = RoomClientMockDeps {
+            client: Arc::new(MockRoomServiceClient {
+                delete_room_fn: Some(Box::new(move |room| {
+                    assert_eq!(room, "room");
+                    match calls_clone.fetch_add(1, Ordering::SeqCst) {
+                        0 => Ok(()),
+                        1 => Err(RoomServiceError::NotFound("not found".into())),
+                        _ => Err(RoomServiceError::Other("boom".into())),
+                    }
+                })),
+                ..Default::default()
+            }),
+        };
+
+        deps.delete_livekit_room(&auth, &room)
+            .await
+            .expect("deletion should succeed");
+        deps.delete_livekit_room(&auth, &room)
+            .await
+            .expect("deleting a missing room should succeed");
+        deps.delete_livekit_room(&auth, &room)
+            .await
+            .expect_err("other errors should surface");
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
 
     // ── real Twirp room-service client ────────────────────────────────────────
@@ -3195,5 +3708,87 @@ mod tests {
             result.is_err(),
             "expected transport/server error, got {result:?}"
         );
+    }
+
+    /// Verifies that RemoveParticipant and DeleteRoom reach their prefixed
+    /// Twirp endpoints with a room-service token, and that twirp not_found
+    /// errors are absorbed while other errors surface.
+    #[tokio::test]
+    async fn test_room_service_client_remove_participant_and_delete_room_via_prefix() {
+        use prost::Message;
+
+        let room = LiveKitRoomAlias("r".into());
+        let identity = LiveKitIdentity("i".into());
+        let auth_for = |server: &TestHttpServer| LiveKitAuth {
+            key: "devkey".into(),
+            secret: "secret".into(),
+            lk_url: format!("{}/livekit/sfu", server.url),
+        };
+
+        // RemoveParticipant: 200 with an (empty) response body.
+        let (server, captured) = spawn_twirp_server(
+            livekit_protocol::RemoveParticipantResponse::default().encode_to_vec(),
+            http::StatusCode::OK,
+        )
+        .await;
+        RealDeps::default()
+            .remove_participant(&auth_for(&server), &room, &identity)
+            .await
+            .expect("remove_participant failed");
+        let (path, auth) = captured.lock().unwrap().clone();
+        assert_eq!(
+            path, "/livekit/sfu/twirp/livekit.RoomService/RemoveParticipant",
+            "path prefix must be preserved"
+        );
+        assert!(
+            auth.starts_with("Bearer "),
+            "expected Bearer token, got {auth:?}"
+        );
+
+        // DeleteRoom: 200 with an (empty) response body.
+        let (server, captured) = spawn_twirp_server(
+            livekit_protocol::DeleteRoomResponse::default().encode_to_vec(),
+            http::StatusCode::OK,
+        )
+        .await;
+        RealDeps::default()
+            .delete_livekit_room(&auth_for(&server), &room)
+            .await
+            .expect("delete_livekit_room failed");
+        assert_eq!(
+            captured.lock().unwrap().0,
+            "/livekit/sfu/twirp/livekit.RoomService/DeleteRoom",
+            "path prefix must be preserved"
+        );
+
+        // not_found: the participant / room is already gone, which is fine.
+        let (server, _captured) = spawn_twirp_server(
+            br#"{"code":"not_found","msg":"participant does not exist"}"#.to_vec(),
+            http::StatusCode::NOT_FOUND,
+        )
+        .await;
+        RealDeps::default()
+            .remove_participant(&auth_for(&server), &room, &identity)
+            .await
+            .expect("removing an absent participant should succeed");
+        RealDeps::default()
+            .delete_livekit_room(&auth_for(&server), &room)
+            .await
+            .expect("deleting a missing room should succeed");
+
+        // Server error: surfaced as Err.
+        let (server, _captured) = spawn_twirp_server(
+            br#"{"code":"internal","msg":"boom"}"#.to_vec(),
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+        RealDeps::default()
+            .remove_participant(&auth_for(&server), &room, &identity)
+            .await
+            .expect_err("expected a server error");
+        RealDeps::default()
+            .delete_livekit_room(&auth_for(&server), &room)
+            .await
+            .expect_err("expected a server error");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod delayed_event_manager;
 pub mod handler;
 pub mod helper;
+pub mod membership_monitor;
 pub mod requests;
 pub mod retry;
 pub mod store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,8 +77,9 @@ async fn main() {
             lk_url: config.lk_url.clone(),
         },
         config.full_access_homeservers.clone(),
-        config.app_service_config,
+        config.app_service_config.clone(),
         config.sanity_check_interval,
+        config.membership_check_interval,
         config.cs_api_url_overrides.clone(),
         store,
         Arc::new(RealDeps {
@@ -86,17 +87,25 @@ async fn main() {
         }),
     );
 
-    let sanity_check_interval_display = if config.sanity_check_interval.is_zero() {
-        "disabled".to_owned()
+    let interval_display = |interval: std::time::Duration| {
+        if interval.is_zero() {
+            "disabled".to_owned()
+        } else {
+            format!("{interval:?}")
+        }
+    };
+    let membership_check_interval_display = if config.app_service_config.is_set_up() {
+        interval_display(config.membership_check_interval)
     } else {
-        format!("{:?}", config.sanity_check_interval)
+        "disabled (not running as an application service)".to_owned()
     };
     info!(
         LIVEKIT_URL = %config.lk_url,
         LIVEKIT_JWT_BIND = %config.lk_jwt_bind,
         LIVEKIT_FULL_ACCESS_HOMESERVERS = ?config.full_access_homeservers,
         SkipVerifyTLS = config.skip_verify_tls,
-        SanityCheckInterval = %sanity_check_interval_display,
+        SanityCheckInterval = %interval_display(config.sanity_check_interval),
+        MembershipCheckInterval = %membership_check_interval_display,
         "Starting service"
     );
 

--- a/src/membership_monitor.rs
+++ b/src/membership_monitor.rs
@@ -1,0 +1,909 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+//! The MembershipMonitor actor: removes participants from the SFU once they
+//! are no longer members of the Matrix room their token was issued for, as
+//! recommended by MSC4195 ("Kicking users from the SFU on room leave/ban").
+//!
+//! # How it works
+//!
+//! Every token this service mints is registered with the monitor together
+//! with the Matrix room and user it was issued for. SFU webhooks then tell
+//! the monitor when the participant actually connects (or leaves), and a
+//! periodic sweep reconciles the tracked participants against the
+//! homeserver:
+//!
+//!   - One `GET /rooms/{roomId}/joined_members` request per Matrix room with
+//!     tracked participants. Every *connected* participant whose user is no
+//!     longer in the returned member list is removed from the SFU.
+//!   - A 403 from that endpoint means none of the application service's users
+//!     is in the room any more. Since the service's user namespace covers the
+//!     homeserver's local users, that is the homeserver having left the room.
+//!     The monitor double-checks that via MSC4502's `/is_joined` and, when
+//!     confirmed, deletes the affected LiveKit rooms outright — nothing
+//!     legitimate is left in them because only local users can publish on
+//!     this SFU. When *not* confirmed, the 403 is treated as a
+//!     misconfiguration (most likely the namespace regex) and nothing is
+//!     removed.
+//!   - Any other failure to determine membership fails open: a homeserver
+//!     outage must not drop every call.
+//!
+//! Participants that were issued a token but have not shown up on the SFU
+//! yet ("pending") are never kicked, since there is nothing to kick. Their
+//! presence is verified against the SFU on every sweep — so a missed
+//! `participant_joined` webhook only delays enforcement — and they are
+//! forgotten once the token they were issued has expired without a connect.
+//!
+//! Tracked participants are persisted through the [`Store`] so enforcement
+//! resumes after a restart; recovered entries start out as pending and are
+//! verified against the SFU by the first sweep.
+//!
+//! # Concurrency model
+//!
+//! `run_loop` is the single task that owns the participant map. Everything
+//! else communicates with it through channels. Sweeps run as separate tasks
+//! so a slow homeserver never stalls webhook processing; at most one sweep
+//! is in flight at any time.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+#[cfg(test)]
+use tokio::sync::oneshot;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use crate::delayed_event_manager::{LookupCsApiUrlFn, WaitGroup};
+use crate::helper::{
+    CsApiUrl, Deps, LiveKitAuth, LiveKitIdentity, LiveKitRoomAlias, MembershipQueryError,
+    ParticipantKey,
+};
+use crate::retry::{Classify, ErrorClass, ExponentialBackoff, retry};
+use crate::store::{Store, StoredParticipant};
+
+/// How many homeserver / SFU requests a sweep has in flight at once.
+const SWEEP_CONCURRENCY: usize = 8;
+
+/// How long a participant who was issued a token but never showed up on the
+/// SFU stays tracked. Matches the lifetime of the tokens this service mints
+/// (see `get_join_token`): once the token has expired, it cannot be used to
+/// connect any more.
+pub const PENDING_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// How long the monitor keeps retrying a single SFU removal before giving up
+/// on it (the next sweep will try again if the participant is still there).
+const SFU_ACTION_BUDGET: Duration = Duration::from_secs(60);
+
+/// A participant to start tracking, i.e. a token that was just minted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Registration {
+    /// The Matrix room the token was issued for.
+    pub matrix_room_id: String,
+    /// The Matrix user the token was issued to.
+    pub matrix_user_id: String,
+    /// The LiveKit room the token grants access to.
+    pub livekit_room: LiveKitRoomAlias,
+    /// The LiveKit identity the token was issued for.
+    pub livekit_identity: LiveKitIdentity,
+}
+
+impl Registration {
+    fn key(&self) -> ParticipantKey {
+        ParticipantKey {
+            room: self.livekit_room.clone(),
+            identity: self.livekit_identity.clone(),
+        }
+    }
+}
+
+/// An SFU-side lifecycle event the monitor tracks.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SfuEvent {
+    /// The participant connected to the room.
+    ParticipantJoined(ParticipantKey),
+    /// The participant left the room, for whatever reason.
+    ParticipantLeft(ParticipantKey),
+    /// The room was closed; every participant in it is gone.
+    RoomFinished(LiveKitRoomAlias),
+}
+
+/// A tracked participant, as seen by the monitor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedParticipant {
+    pub stored: StoredParticipant,
+    /// Whether the participant is known to be connected to the SFU.
+    pub connected: bool,
+}
+
+/// Configuration of a [`MembershipMonitor`].
+#[derive(Debug, Clone)]
+pub struct MembershipMonitorConfig {
+    /// The period between sweeps.
+    pub check_interval: Duration,
+    /// The server name of the homeserver this service is registered with.
+    pub hs_server_name: String,
+    /// The token authenticating requests to the homeserver.
+    pub as_token: String,
+}
+
+/// A message to the actor loop.
+enum Msg {
+    Register(Registration),
+    Sfu(SfuEvent),
+    /// Runs a sweep now (in addition to the periodic ones) and replies once
+    /// its outcome has been applied.
+    #[cfg(test)]
+    Sweep(oneshot::Sender<()>),
+    /// Replies with the current participant map.
+    #[cfg(test)]
+    Snapshot(oneshot::Sender<Vec<TrackedParticipant>>),
+}
+
+/// The membership monitor actor. See the module documentation.
+pub struct MembershipMonitor {
+    cancel: CancellationToken,
+    msg_tx: mpsc::Sender<Msg>,
+    /// Set to true when run_loop has exited.
+    loop_done_tx: watch::Sender<bool>,
+    /// Set to true once start-up recovery of stored participants is done.
+    recovery_done_tx: watch::Sender<bool>,
+}
+
+/// The receiving ends consumed by the actor loop, plus everything else the
+/// loop needs that is not shared with the outside.
+pub(crate) struct LoopContext {
+    msg_rx: mpsc::Receiver<Msg>,
+    config: MembershipMonitorConfig,
+    deps: Arc<dyn Deps>,
+    lk_auth: LiveKitAuth,
+    lookup_cs_api_url: LookupCsApiUrlFn,
+    store: Option<Arc<dyn Store>>,
+    /// Keys of participants that were removed from the SFU because they lost
+    /// their room membership. The handler stops any delayed-event job for
+    /// them.
+    revoked_tx: mpsc::Sender<ParticipantKey>,
+}
+
+impl MembershipMonitor {
+    /// Constructs a monitor and starts its actor loop.
+    ///
+    /// `parent_cancel` ties the monitor's lifetime to its owner: cancelling
+    /// the parent shuts the monitor down too. [`Self::close`] additionally
+    /// waits for the loop to exit.
+    pub fn new(
+        parent_cancel: &CancellationToken,
+        config: MembershipMonitorConfig,
+        deps: Arc<dyn Deps>,
+        lk_auth: LiveKitAuth,
+        lookup_cs_api_url: LookupCsApiUrlFn,
+        store: Option<Arc<dyn Store>>,
+        revoked_tx: mpsc::Sender<ParticipantKey>,
+    ) -> Arc<Self> {
+        let (monitor, ctx) = Self::new_without_loop(
+            parent_cancel,
+            config,
+            deps,
+            lk_auth,
+            lookup_cs_api_url,
+            store,
+            revoked_tx,
+        );
+        let looped = monitor.clone();
+        tokio::spawn(async move { looped.run_loop(ctx).await });
+        monitor
+    }
+
+    /// Constructs a monitor without starting its actor loop, handing the
+    /// loop's context to the caller.
+    pub(crate) fn new_without_loop(
+        parent_cancel: &CancellationToken,
+        config: MembershipMonitorConfig,
+        deps: Arc<dyn Deps>,
+        lk_auth: LiveKitAuth,
+        lookup_cs_api_url: LookupCsApiUrlFn,
+        store: Option<Arc<dyn Store>>,
+        revoked_tx: mpsc::Sender<ParticipantKey>,
+    ) -> (Arc<Self>, LoopContext) {
+        let (msg_tx, msg_rx) = mpsc::channel(256);
+        let (loop_done_tx, _) = watch::channel(false);
+        let (recovery_done_tx, _) = watch::channel(false);
+        let monitor = Arc::new(Self {
+            cancel: parent_cancel.child_token(),
+            msg_tx,
+            loop_done_tx,
+            recovery_done_tx,
+        });
+        let ctx = LoopContext {
+            msg_rx,
+            config,
+            deps,
+            lk_auth,
+            lookup_cs_api_url,
+            store,
+            revoked_tx,
+        };
+        (monitor, ctx)
+    }
+
+    /// A watch receiver that flips to true once start-up recovery completed.
+    #[cfg(test)]
+    pub(crate) fn recovery_done(&self) -> watch::Receiver<bool> {
+        self.recovery_done_tx.subscribe()
+    }
+
+    /// Starts tracking a participant a token was just minted for. Replaces
+    /// any earlier registration for the same (room, identity).
+    pub async fn register(&self, registration: Registration) {
+        self.send(Msg::Register(registration)).await;
+    }
+
+    /// Feeds an SFU webhook event to the monitor.
+    pub async fn notify_sfu_event(&self, event: SfuEvent) {
+        self.send(Msg::Sfu(event)).await;
+    }
+
+    /// Runs a sweep now and waits until its outcome has been applied.
+    #[cfg(test)]
+    pub(crate) async fn sweep_now(&self) {
+        let (tx, rx) = oneshot::channel();
+        self.send(Msg::Sweep(tx)).await;
+        let _ = rx.await;
+    }
+
+    /// The participants currently tracked.
+    #[cfg(test)]
+    pub(crate) async fn snapshot(&self) -> Vec<TrackedParticipant> {
+        let (tx, rx) = oneshot::channel();
+        self.send(Msg::Snapshot(tx)).await;
+        rx.await.unwrap_or_default()
+    }
+
+    async fn send(&self, msg: Msg) {
+        tokio::select! {
+            _ = self.cancel.cancelled() => {
+                debug!("MembershipMonitor: dropping message after shutdown");
+            }
+            sent = self.msg_tx.send(msg) => {
+                if sent.is_err() {
+                    debug!("MembershipMonitor: dropping message, loop is gone");
+                }
+            }
+        }
+    }
+
+    /// Shuts the monitor down and waits for the loop to exit.
+    pub async fn close(&self) {
+        self.cancel.cancel();
+        let mut done = self.loop_done_tx.subscribe();
+        let wait = async {
+            while !*done.borrow_and_update() {
+                if done.changed().await.is_err() {
+                    break;
+                }
+            }
+        };
+        if tokio::time::timeout(Duration::from_secs(10), wait)
+            .await
+            .is_err()
+        {
+            warn!("MembershipMonitor: close() timed out");
+        }
+    }
+
+    /// The actor task owning the participant map. Runs until cancelled.
+    pub(crate) async fn run_loop(self: Arc<Self>, mut ctx: LoopContext) {
+        let mut participants: HashMap<ParticipantKey, TrackedParticipant> = HashMap::new();
+        let background = WaitGroup::default();
+
+        // Store writes go through a dedicated writer task so a slow store
+        // cannot stall the loop, while a single writer preserves the order the
+        // loop decided on (a save followed by a delete must stay a delete).
+        let (store_tx, store_writer) = match &ctx.store {
+            Some(store) => {
+                let store = store.clone();
+                let (tx, mut op_rx) = mpsc::channel::<StoreOp>(256);
+                let writer = tokio::spawn(async move {
+                    while let Some(op) = op_rx.recv().await {
+                        match op {
+                            StoreOp::Save(participant) => {
+                                let key = participant.key();
+                                if let Err(err) = store.save_participant(&key, &participant).await {
+                                    error!(key = ?key, err = %err,
+                                        "MembershipMonitor: failed to store participant");
+                                }
+                            }
+                            StoreOp::Delete(key) => {
+                                if let Err(err) = store.delete_participant(&key).await {
+                                    error!(key = ?key, err = %err,
+                                        "MembershipMonitor: failed to delete stored participant");
+                                }
+                            }
+                        }
+                    }
+                });
+                (Some(tx), Some(writer))
+            }
+            None => (None, None),
+        };
+        let enqueue_store_op = |op: StoreOp| async {
+            if let Some(tx) = &store_tx
+                && tx.send(op).await.is_err()
+            {
+                error!("MembershipMonitor: store writer is gone, dropping store operation");
+            }
+        };
+
+        // Recover the participants tracked before the last shutdown. They
+        // start out as pending: the first sweep verifies who is actually still
+        // connected.
+        if let Some(store) = &ctx.store {
+            match store.all_participants().await {
+                Err(err) => {
+                    error!(err = %err, "MembershipMonitor: failed to load stored participants");
+                }
+                Ok(stored) => {
+                    for participant in stored {
+                        let key = participant.key();
+                        debug!(matrix_room = %participant.matrix_room_id,
+                            matrix_id = %participant.matrix_user_id, room = %key.room,
+                            lk_id = %key.identity, "MembershipMonitor: recovered stored participant");
+                        participants.insert(
+                            key,
+                            TrackedParticipant {
+                                stored: participant,
+                                connected: false,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        self.recovery_done_tx.send_replace(true);
+
+        // Sweeps report back through this channel. `sweep_in_flight` keeps it
+        // to one sweep at a time; `sweep_waiters` are answered once the next
+        // outcome has been applied.
+        let (sweep_tx, mut sweep_rx) = mpsc::channel::<SweepOutcome>(1);
+        let mut sweep_in_flight = false;
+        #[cfg(test)]
+        let mut sweep_waiters: Vec<oneshot::Sender<()>> = Vec::new();
+
+        let mut ticker = tokio::time::interval_at(
+            tokio::time::Instant::now() + ctx.config.check_interval,
+            ctx.config.check_interval,
+        );
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        // Start reconciling recovered participants right away rather than a
+        // full interval later.
+        let mut sweep_requested = !participants.is_empty();
+
+        loop {
+            if sweep_requested && !sweep_in_flight {
+                sweep_requested = false;
+                sweep_in_flight = true;
+                let input = SweepInput::from_participants(&participants);
+                let sweep_tx = sweep_tx.clone();
+                let deps = ctx.deps.clone();
+                let lk_auth = ctx.lk_auth.clone();
+                let lookup = ctx.lookup_cs_api_url.clone();
+                let config = ctx.config.clone();
+                let cancel = self.cancel.clone();
+                let guard = background.add();
+                tokio::spawn(async move {
+                    let _guard = guard;
+                    let outcome = tokio::select! {
+                        _ = cancel.cancelled() => return,
+                        outcome = sweep(deps, lk_auth, lookup, config, input) => outcome,
+                    };
+                    let _ = sweep_tx.send(outcome).await;
+                });
+            }
+
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    debug!("MembershipMonitor: loop exiting");
+                    break;
+                }
+
+                _ = ticker.tick() => {
+                    if sweep_in_flight {
+                        warn!("MembershipMonitor: previous sweep still running, skipping this one");
+                    } else if !participants.is_empty() {
+                        sweep_requested = true;
+                    }
+                }
+
+                Some(outcome) = sweep_rx.recv() => {
+                    sweep_in_flight = false;
+                    let actions = apply_sweep_outcome(&mut participants, outcome, Utc::now());
+                    for key in &actions.forgotten {
+                        enqueue_store_op(StoreOp::Delete(key.clone())).await;
+                    }
+                    for key in &actions.revoked {
+                        enqueue_store_op(StoreOp::Delete(key.clone())).await;
+                        tokio::select! {
+                            _ = self.cancel.cancelled() => {}
+                            _ = ctx.revoked_tx.send(key.clone()) => {}
+                        }
+                    }
+                    for key in actions.kick {
+                        spawn_sfu_action(
+                            &background,
+                            &self.cancel,
+                            ctx.deps.clone(),
+                            ctx.lk_auth.clone(),
+                            SfuAction::RemoveParticipant(key),
+                        );
+                    }
+                    for room in actions.delete_rooms {
+                        spawn_sfu_action(
+                            &background,
+                            &self.cancel,
+                            ctx.deps.clone(),
+                            ctx.lk_auth.clone(),
+                            SfuAction::DeleteRoom(room),
+                        );
+                    }
+                    #[cfg(test)]
+                    for waiter in sweep_waiters.drain(..) {
+                        let _ = waiter.send(());
+                    }
+                }
+
+                Some(msg) = ctx.msg_rx.recv() => {
+                    match msg {
+                        Msg::Register(registration) => {
+                            let key = registration.key();
+                            // A re-issued token for a connected participant
+                            // keeps its connected state; only the timestamp
+                            // moves.
+                            let connected = participants.get(&key).is_some_and(|p| p.connected);
+                            let stored = StoredParticipant {
+                                matrix_room_id: registration.matrix_room_id,
+                                matrix_user_id: registration.matrix_user_id,
+                                livekit_room: registration.livekit_room,
+                                livekit_identity: registration.livekit_identity,
+                                registered_at: Utc::now(),
+                            };
+                            debug!(matrix_room = %stored.matrix_room_id,
+                                matrix_id = %stored.matrix_user_id, room = %key.room,
+                                lk_id = %key.identity, connected,
+                                "MembershipMonitor: tracking participant");
+                            enqueue_store_op(StoreOp::Save(stored.clone())).await;
+                            participants.insert(key, TrackedParticipant { stored, connected });
+                        }
+
+                        Msg::Sfu(SfuEvent::ParticipantJoined(key)) => {
+                            match participants.get_mut(&key) {
+                                Some(participant) => {
+                                    debug!(room = %key.room, lk_id = %key.identity,
+                                        "MembershipMonitor: participant connected");
+                                    participant.connected = true;
+                                }
+                                None => {
+                                    debug!(room = %key.room, lk_id = %key.identity,
+                                        "MembershipMonitor: ignoring connect of untracked participant");
+                                }
+                            }
+                        }
+
+                        Msg::Sfu(SfuEvent::ParticipantLeft(key)) => {
+                            if participants.remove(&key).is_some() {
+                                debug!(room = %key.room, lk_id = %key.identity,
+                                    "MembershipMonitor: participant left, no longer tracking");
+                                enqueue_store_op(StoreOp::Delete(key)).await;
+                            }
+                        }
+
+                        Msg::Sfu(SfuEvent::RoomFinished(room)) => {
+                            let gone: Vec<ParticipantKey> = participants
+                                .keys()
+                                .filter(|key| key.room == room)
+                                .cloned()
+                                .collect();
+                            if !gone.is_empty() {
+                                debug!(room = %room, count = gone.len(),
+                                    "MembershipMonitor: room finished, no longer tracking its participants");
+                            }
+                            for key in gone {
+                                participants.remove(&key);
+                                enqueue_store_op(StoreOp::Delete(key)).await;
+                            }
+                        }
+
+                        #[cfg(test)]
+                        Msg::Sweep(reply) => {
+                            sweep_waiters.push(reply);
+                            sweep_requested = true;
+                        }
+
+                        #[cfg(test)]
+                        Msg::Snapshot(reply) => {
+                            let _ = reply.send(participants.values().cloned().collect());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Wait for in-flight sweeps and SFU actions, then let the writer
+        // drain its queue before signalling completion.
+        background.wait().await;
+        drop(store_tx);
+        if let Some(writer) = store_writer {
+            let _ = writer.await;
+        }
+        self.loop_done_tx.send_replace(true);
+    }
+}
+
+/// A persistence operation queued for the store-writer task.
+enum StoreOp {
+    Save(StoredParticipant),
+    Delete(ParticipantKey),
+}
+
+// ── sweeps ───────────────────────────────────────────────────────────────────
+
+/// What a sweep needs to know, snapshotted from the participant map.
+#[derive(Debug, Default, PartialEq)]
+struct SweepInput {
+    /// Participants not (yet) known to be connected, whose presence on the
+    /// SFU is to be verified.
+    pending: Vec<ParticipantKey>,
+    /// The Matrix rooms with tracked participants.
+    rooms: Vec<String>,
+}
+
+impl SweepInput {
+    fn from_participants(participants: &HashMap<ParticipantKey, TrackedParticipant>) -> Self {
+        let pending = participants
+            .iter()
+            .filter(|(_, p)| !p.connected)
+            .map(|(key, _)| key.clone())
+            .collect();
+        let rooms: HashSet<&str> = participants
+            .values()
+            .map(|p| p.stored.matrix_room_id.as_str())
+            .collect();
+        let mut rooms: Vec<String> = rooms.into_iter().map(str::to_owned).collect();
+        rooms.sort();
+        Self { pending, rooms }
+    }
+}
+
+/// The homeserver's answer about one Matrix room.
+#[derive(Debug, PartialEq)]
+enum RoomMembership {
+    /// The users currently joined to the room.
+    Joined(HashSet<String>),
+    /// The homeserver itself is no longer in the room.
+    ServerLeft,
+    /// Membership could not be determined; leave the room's participants be.
+    Unknown,
+}
+
+/// What a sweep found out.
+#[derive(Debug, Default)]
+struct SweepOutcome {
+    /// Pending participants found present on the SFU.
+    present: Vec<ParticipantKey>,
+    /// Pending participants confirmed absent from the SFU.
+    absent: Vec<ParticipantKey>,
+    /// Membership per Matrix room.
+    rooms: Vec<(String, RoomMembership)>,
+}
+
+/// Queries the SFU and the homeserver for everything in `input`.
+async fn sweep(
+    deps: Arc<dyn Deps>,
+    lk_auth: LiveKitAuth,
+    lookup_cs_api_url: LookupCsApiUrlFn,
+    config: MembershipMonitorConfig,
+    input: SweepInput,
+) -> SweepOutcome {
+    let mut outcome = SweepOutcome::default();
+
+    // Presence of pending participants.
+    let mut presence = futures::stream::iter(input.pending)
+        .map(|key| {
+            let deps = deps.clone();
+            let lk_auth = lk_auth.clone();
+            async move {
+                let result = deps
+                    .participant_exists(&lk_auth, &key.room, &key.identity)
+                    .await;
+                (key, result)
+            }
+        })
+        .buffer_unordered(SWEEP_CONCURRENCY);
+    while let Some((key, result)) = presence.next().await {
+        match result {
+            Ok(true) => outcome.present.push(key),
+            Ok(false) => outcome.absent.push(key),
+            Err(err) => {
+                warn!(room = %key.room, lk_id = %key.identity, err = %err,
+                    "MembershipMonitor: could not verify presence on the SFU");
+            }
+        }
+    }
+
+    if input.rooms.is_empty() {
+        return outcome;
+    }
+
+    // Room membership. Everything below needs the homeserver's C-S API.
+    let cs_api_url = match lookup_cs_api_url(config.hs_server_name.clone()).await {
+        Ok(url) => url,
+        Err(err) => {
+            warn!(server_name = %config.hs_server_name, err = %err,
+                "MembershipMonitor: could not resolve the Client-Server API, skipping membership checks");
+            outcome.rooms = input
+                .rooms
+                .into_iter()
+                .map(|room| (room, RoomMembership::Unknown))
+                .collect();
+            return outcome;
+        }
+    };
+
+    let mut memberships = futures::stream::iter(input.rooms)
+        .map(|room_id| {
+            let deps = deps.clone();
+            let cs_api_url = cs_api_url.clone();
+            let config = config.clone();
+            async move {
+                let membership =
+                    query_room_membership(&*deps, &cs_api_url, &config, &room_id).await;
+                (room_id, membership)
+            }
+        })
+        .buffer_unordered(SWEEP_CONCURRENCY);
+    while let Some(entry) = memberships.next().await {
+        outcome.rooms.push(entry);
+    }
+    outcome
+}
+
+/// Determines the membership of one Matrix room, see [`RoomMembership`].
+async fn query_room_membership(
+    deps: &dyn Deps,
+    cs_api_url: &CsApiUrl,
+    config: &MembershipMonitorConfig,
+    room_id: &str,
+) -> RoomMembership {
+    match deps
+        .get_joined_members(cs_api_url, room_id, &config.as_token)
+        .await
+    {
+        Ok(members) => RoomMembership::Joined(members),
+        Err(MembershipQueryError::NotInRoom) => {
+            // Confirm before doing anything drastic: a 403 with the server
+            // still joined points at a misconfigured user namespace.
+            match deps
+                .is_server_joined(
+                    cs_api_url,
+                    room_id,
+                    &config.hs_server_name,
+                    &config.as_token,
+                )
+                .await
+            {
+                Ok(false) => RoomMembership::ServerLeft,
+                Ok(true) => {
+                    error!(matrix_room = %room_id,
+                        "MembershipMonitor: joined_members was refused although the homeserver is \
+                         in the room; check that the application service's user namespace covers \
+                         the homeserver's local users. Leaving the room's participants untouched.");
+                    RoomMembership::Unknown
+                }
+                Err(err) => {
+                    warn!(matrix_room = %room_id, err = %err,
+                        "MembershipMonitor: joined_members was refused and the homeserver's own \
+                         membership could not be verified, leaving the room's participants untouched");
+                    RoomMembership::Unknown
+                }
+            }
+        }
+        Err(MembershipQueryError::Other(err)) => {
+            warn!(matrix_room = %room_id, err = %err,
+                "MembershipMonitor: could not fetch joined members, leaving the room's participants untouched");
+            RoomMembership::Unknown
+        }
+    }
+}
+
+/// What the loop has to do after applying a sweep outcome.
+#[derive(Debug, Default, PartialEq)]
+struct SweepActions {
+    /// Participants to remove from the SFU (they lost their room membership).
+    kick: Vec<ParticipantKey>,
+    /// LiveKit rooms to delete (the homeserver left their Matrix room).
+    delete_rooms: Vec<LiveKitRoomAlias>,
+    /// Participants no longer tracked because they lost their room
+    /// membership: `kick` plus everyone in `delete_rooms`. The handler stops
+    /// their delayed-event jobs.
+    revoked: Vec<ParticipantKey>,
+    /// Participants no longer tracked for other reasons (their token expired
+    /// without a connect).
+    forgotten: Vec<ParticipantKey>,
+}
+
+/// Applies a sweep outcome to the participant map and returns the actions to
+/// take. Pure, so it can be tested without the actor.
+fn apply_sweep_outcome(
+    participants: &mut HashMap<ParticipantKey, TrackedParticipant>,
+    outcome: SweepOutcome,
+    now: DateTime<Utc>,
+) -> SweepActions {
+    let mut actions = SweepActions::default();
+
+    for key in outcome.present {
+        if let Some(participant) = participants.get_mut(&key)
+            && !participant.connected
+        {
+            debug!(room = %key.room, lk_id = %key.identity,
+                "MembershipMonitor: participant found on the SFU");
+            participant.connected = true;
+        }
+    }
+
+    let pending_ttl = chrono::Duration::from_std(PENDING_TTL).unwrap_or_default();
+    for key in outcome.absent {
+        let expired = participants
+            .get(&key)
+            .is_some_and(|p| !p.connected && p.stored.registered_at + pending_ttl <= now);
+        if expired {
+            debug!(room = %key.room, lk_id = %key.identity,
+                "MembershipMonitor: token expired without a connect, no longer tracking");
+            participants.remove(&key);
+            actions.forgotten.push(key);
+        }
+    }
+
+    for (room_id, membership) in outcome.rooms {
+        match membership {
+            RoomMembership::Joined(members) => {
+                let kicked: Vec<ParticipantKey> = participants
+                    .iter()
+                    .filter(|(_, p)| {
+                        p.stored.matrix_room_id == room_id
+                            && p.connected
+                            && !members.contains(&p.stored.matrix_user_id)
+                    })
+                    .map(|(key, _)| key.clone())
+                    .collect();
+                for key in kicked {
+                    if let Some(participant) = participants.remove(&key) {
+                        info!(matrix_room = %room_id, matrix_id = %participant.stored.matrix_user_id,
+                            room = %key.room, lk_id = %key.identity,
+                            "MembershipMonitor: user is no longer a room member, removing from the SFU");
+                    }
+                    actions.revoked.push(key.clone());
+                    actions.kick.push(key);
+                }
+            }
+            RoomMembership::ServerLeft => {
+                let gone: Vec<ParticipantKey> = participants
+                    .iter()
+                    .filter(|(_, p)| p.stored.matrix_room_id == room_id)
+                    .map(|(key, _)| key.clone())
+                    .collect();
+                let mut rooms: Vec<LiveKitRoomAlias> = Vec::new();
+                for key in gone {
+                    participants.remove(&key);
+                    if !rooms.contains(&key.room) {
+                        rooms.push(key.room.clone());
+                    }
+                    actions.revoked.push(key);
+                }
+                for room in rooms {
+                    info!(matrix_room = %room_id, room = %room,
+                        "MembershipMonitor: homeserver left the room, deleting the LiveKit room");
+                    actions.delete_rooms.push(room);
+                }
+            }
+            RoomMembership::Unknown => {}
+        }
+    }
+
+    actions
+}
+
+// ── SFU actions ──────────────────────────────────────────────────────────────
+
+/// A removal to perform on the SFU.
+#[derive(Debug, Clone)]
+enum SfuAction {
+    RemoveParticipant(ParticipantKey),
+    DeleteRoom(LiveKitRoomAlias),
+}
+
+/// A failed SFU action. Always retried: the SFU is local infrastructure, so
+/// failures are expected to be transient.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct SfuActionError(String);
+
+impl Classify for SfuActionError {
+    fn classify(&self) -> ErrorClass {
+        ErrorClass::Transient
+    }
+}
+
+/// Performs `action` in a background task, retrying transient failures for
+/// up to [`SFU_ACTION_BUDGET`].
+fn spawn_sfu_action(
+    background: &WaitGroup,
+    cancel: &CancellationToken,
+    deps: Arc<dyn Deps>,
+    lk_auth: LiveKitAuth,
+    action: SfuAction,
+) {
+    let guard = background.add();
+    let cancel = cancel.clone();
+    tokio::spawn(async move {
+        let _guard = guard;
+        let result = retry(
+            &cancel,
+            ExponentialBackoff::service_default(),
+            SFU_ACTION_BUDGET,
+            || {
+                let deps = deps.clone();
+                let lk_auth = lk_auth.clone();
+                let action = action.clone();
+                let cancel = cancel.clone();
+                async move {
+                    let attempt = async {
+                        match &action {
+                            SfuAction::RemoveParticipant(key) => {
+                                deps.remove_participant(&lk_auth, &key.room, &key.identity)
+                                    .await
+                            }
+                            SfuAction::DeleteRoom(room) => {
+                                deps.delete_livekit_room(&lk_auth, room).await
+                            }
+                        }
+                    };
+                    tokio::select! {
+                        _ = cancel.cancelled() => Err(SfuActionError("cancelled".into())),
+                        result = attempt => result.map_err(SfuActionError),
+                    }
+                }
+            },
+        )
+        .await;
+        match (&action, result) {
+            (SfuAction::RemoveParticipant(key), Ok(())) => {
+                info!(room = %key.room, lk_id = %key.identity,
+                    "MembershipMonitor: removed participant from the SFU");
+            }
+            (SfuAction::DeleteRoom(room), Ok(())) => {
+                info!(room = %room, "MembershipMonitor: deleted LiveKit room");
+            }
+            (SfuAction::RemoveParticipant(key), Err(err)) => {
+                if !cancel.is_cancelled() {
+                    error!(room = %key.room, lk_id = %key.identity, err = %err,
+                        "MembershipMonitor: failed to remove participant from the SFU");
+                }
+            }
+            (SfuAction::DeleteRoom(room), Err(err)) => {
+                if !cancel.is_cancelled() {
+                    error!(room = %room, err = %err,
+                        "MembershipMonitor: failed to delete LiveKit room");
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+#[path = "membership_monitor_tests.rs"]
+mod tests;

--- a/src/membership_monitor_tests.rs
+++ b/src/membership_monitor_tests.rs
@@ -1,0 +1,903 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+//! MembershipMonitor tests: registration and webhook bookkeeping, the sweep
+//! decisions, persistence and recovery, and the periodic schedule.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::helper::{livekit_identity_for, livekit_room_alias_for};
+use crate::store::test_support::new_in_memory_store;
+
+// ── test deps ─────────────────────────────────────────────────────────────────
+
+type ParticipantExistsFn =
+    Box<dyn Fn(&LiveKitRoomAlias, &LiveKitIdentity) -> Result<bool, String> + Send + Sync>;
+type JoinedMembersFn =
+    Box<dyn Fn(&str) -> Result<HashSet<String>, MembershipQueryError> + Send + Sync>;
+type IsServerJoinedFn = Box<dyn Fn(&str, &str) -> Result<bool, String> + Send + Sync>;
+
+/// A [`Deps`] implementation for the monitor: membership and presence are
+/// scripted per test, removals are recorded and reported through channels.
+/// Un-mocked SFU presence checks report the participant present.
+#[derive(Default)]
+struct MonitorTestDeps {
+    participant_exists_fn: Option<ParticipantExistsFn>,
+    get_joined_members_fn: Option<JoinedMembersFn>,
+    is_server_joined_fn: Option<IsServerJoinedFn>,
+    /// Every room `get_joined_members` was called for.
+    joined_members_calls: Arc<Mutex<Vec<String>>>,
+    /// Every participant removed from the SFU.
+    removed_tx: Option<mpsc::UnboundedSender<ParticipantKey>>,
+    /// Every LiveKit room deleted.
+    deleted_tx: Option<mpsc::UnboundedSender<LiveKitRoomAlias>>,
+}
+
+#[async_trait::async_trait]
+impl Deps for MonitorTestDeps {
+    fn new_room_service_client(
+        &self,
+        _url: &str,
+        _key: &str,
+        _secret: &str,
+    ) -> Arc<dyn crate::helper::RoomServiceClient> {
+        panic!("new_room_service_client must not be called by the monitor");
+    }
+
+    async fn participant_exists(
+        &self,
+        _lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+        identity: &LiveKitIdentity,
+    ) -> Result<bool, String> {
+        match &self.participant_exists_fn {
+            Some(f) => f(room, identity),
+            None => Ok(true),
+        }
+    }
+
+    async fn remove_participant(
+        &self,
+        _lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+        identity: &LiveKitIdentity,
+    ) -> Result<(), String> {
+        if let Some(tx) = &self.removed_tx {
+            let _ = tx.send(ParticipantKey {
+                room: room.clone(),
+                identity: identity.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn delete_livekit_room(
+        &self,
+        _lk_auth: &LiveKitAuth,
+        room: &LiveKitRoomAlias,
+    ) -> Result<(), String> {
+        if let Some(tx) = &self.deleted_tx {
+            let _ = tx.send(room.clone());
+        }
+        Ok(())
+    }
+
+    async fn get_joined_members(
+        &self,
+        _cs_api_url: &CsApiUrl,
+        room_id: &str,
+        _as_token: &str,
+    ) -> Result<HashSet<String>, MembershipQueryError> {
+        self.joined_members_calls
+            .lock()
+            .unwrap()
+            .push(room_id.to_owned());
+        match &self.get_joined_members_fn {
+            Some(f) => f(room_id),
+            None => panic!("get_joined_members not mocked"),
+        }
+    }
+
+    async fn is_server_joined(
+        &self,
+        _cs_api_url: &CsApiUrl,
+        room_id: &str,
+        server_name: &str,
+        _as_token: &str,
+    ) -> Result<bool, String> {
+        match &self.is_server_joined_fn {
+            Some(f) => f(room_id, server_name),
+            None => panic!("is_server_joined not mocked"),
+        }
+    }
+}
+
+/// A `get_joined_members` mock reporting the given users joined to every room.
+fn members(users: &[&str]) -> Option<JoinedMembersFn> {
+    let users: HashSet<String> = users.iter().map(|u| (*u).to_owned()).collect();
+    Some(Box::new(move |_| Ok(users.clone())))
+}
+
+/// A `get_joined_members` mock refusing every room with a 403.
+fn not_in_room() -> Option<JoinedMembersFn> {
+    Some(Box::new(|_| Err(MembershipQueryError::NotInRoom)))
+}
+
+/// An `is_server_joined` mock with a fixed answer.
+fn server_joined(joined: bool) -> Option<IsServerJoinedFn> {
+    Some(Box::new(move |_, _| Ok(joined)))
+}
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const HS_SERVER_NAME: &str = "example.com";
+const ROOM_A: &str = "!a:example.com";
+const ROOM_B: &str = "!b:example.com";
+const ALICE: &str = "@alice:example.com";
+const BOB: &str = "@bob:remote.example.org";
+
+/// The handles a test needs to drive and observe a monitor.
+struct Harness {
+    monitor: Arc<MembershipMonitor>,
+    cancel: CancellationToken,
+    revoked_rx: mpsc::Receiver<ParticipantKey>,
+    removed_rx: mpsc::UnboundedReceiver<ParticipantKey>,
+    deleted_rx: mpsc::UnboundedReceiver<LiveKitRoomAlias>,
+    joined_members_calls: Arc<Mutex<Vec<String>>>,
+}
+
+/// A CS-API lookup that always resolves.
+fn resolving_lookup() -> LookupCsApiUrlFn {
+    Arc::new(|_| Box::pin(async { Ok(CsApiUrl("https://matrix.example.com".into())) }))
+}
+
+/// A CS-API lookup that always fails.
+fn failing_lookup() -> LookupCsApiUrlFn {
+    Arc::new(|_| Box::pin(async { Err("no such server".to_owned()) }))
+}
+
+fn new_harness(deps: MonitorTestDeps, store: Option<Arc<dyn Store>>) -> Harness {
+    new_harness_with(
+        deps,
+        store,
+        Duration::from_secs(60 * 60),
+        resolving_lookup(),
+    )
+}
+
+fn new_harness_with(
+    mut deps: MonitorTestDeps,
+    store: Option<Arc<dyn Store>>,
+    check_interval: Duration,
+    lookup: LookupCsApiUrlFn,
+) -> Harness {
+    let (removed_tx, removed_rx) = mpsc::unbounded_channel();
+    let (deleted_tx, deleted_rx) = mpsc::unbounded_channel();
+    deps.removed_tx = Some(removed_tx);
+    deps.deleted_tx = Some(deleted_tx);
+    let joined_members_calls = deps.joined_members_calls.clone();
+
+    let (revoked_tx, revoked_rx) = mpsc::channel(64);
+    let cancel = CancellationToken::new();
+    let monitor = MembershipMonitor::new(
+        &cancel,
+        MembershipMonitorConfig {
+            check_interval,
+            hs_server_name: HS_SERVER_NAME.into(),
+            as_token: "as_token".into(),
+        },
+        Arc::new(deps),
+        LiveKitAuth::default(),
+        lookup,
+        store,
+        revoked_tx,
+    );
+    Harness {
+        monitor,
+        cancel,
+        revoked_rx,
+        removed_rx,
+        deleted_rx,
+        joined_members_calls,
+    }
+}
+
+/// A registration for `mxid` in `room_id`, in the given slot and with the
+/// given member ID.
+fn registration(room_id: &str, mxid: &str, slot_id: &str, member_id: &str) -> Registration {
+    Registration {
+        matrix_room_id: room_id.to_owned(),
+        matrix_user_id: mxid.to_owned(),
+        livekit_room: livekit_room_alias_for(room_id, slot_id),
+        livekit_identity: livekit_identity_for(mxid, "DEVICE", member_id),
+    }
+}
+
+/// Registers the participant and reports them connected.
+async fn register_connected(monitor: &MembershipMonitor, reg: &Registration) {
+    monitor.register(reg.clone()).await;
+    monitor
+        .notify_sfu_event(SfuEvent::ParticipantJoined(reg.key()))
+        .await;
+}
+
+/// Receives from a channel, panicking when nothing arrives in time.
+async fn recv_timeout<T>(rx: &mut mpsc::UnboundedReceiver<T>, what: &str) -> T {
+    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+        .unwrap_or_else(|| panic!("channel closed while waiting for {what}"))
+}
+
+/// Receives from a bounded channel, panicking when nothing arrives in time.
+async fn recv_bounded_timeout<T>(rx: &mut mpsc::Receiver<T>, what: &str) -> T {
+    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+        .unwrap_or_else(|| panic!("channel closed while waiting for {what}"))
+}
+
+/// Asserts that nothing arrives on the channel for a little while.
+async fn assert_quiet<T: std::fmt::Debug>(rx: &mut mpsc::UnboundedReceiver<T>, what: &str) {
+    if let Ok(Some(item)) = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+        panic!("unexpected {what}: {item:?}");
+    }
+}
+
+fn keys(snapshot: &[TrackedParticipant]) -> HashSet<ParticipantKey> {
+    snapshot.iter().map(|p| p.stored.key()).collect()
+}
+
+// ── kicking ───────────────────────────────────────────────────────────────────
+
+/// A connected participant whose user is no longer in the room is removed
+/// from the SFU, dropped from tracking and reported as revoked.
+#[tokio::test]
+async fn connected_non_member_is_kicked() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_eq!(
+        recv_timeout(&mut h.removed_rx, "removal").await,
+        alice.key()
+    );
+    assert_eq!(
+        recv_bounded_timeout(&mut h.revoked_rx, "revocation").await,
+        alice.key()
+    );
+    assert!(h.monitor.snapshot().await.is_empty());
+    assert_quiet(&mut h.deleted_rx, "room deletion").await;
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// A connected participant whose user is still in the room stays.
+#[tokio::test]
+async fn member_is_left_alone() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[ALICE]),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    let snapshot = h.monitor.snapshot().await;
+    assert_eq!(keys(&snapshot), HashSet::from([alice.key()]));
+    assert!(snapshot[0].connected);
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// A participant who has not connected yet cannot be kicked: they stay
+/// tracked while absent from the SFU, and are removed on the first sweep
+/// after they show up — whether that is learnt from a webhook or from the
+/// SFU itself.
+#[tokio::test]
+async fn pending_participant_is_kicked_once_connected() {
+    let present = Arc::new(AtomicBool::new(false));
+    let present_clone = present.clone();
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            participant_exists_fn: Some(Box::new(move |_, _| {
+                Ok(present_clone.load(Ordering::SeqCst))
+            })),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    h.monitor.register(alice.clone()).await;
+
+    // Absent from the SFU: nothing to kick, but still tracked.
+    h.monitor.sweep_now().await;
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    let snapshot = h.monitor.snapshot().await;
+    assert_eq!(keys(&snapshot), HashSet::from([alice.key()]));
+    assert!(!snapshot[0].connected);
+
+    // Present on the SFU (the join webhook was missed): the sweep notices
+    // and, in the same pass, kicks.
+    present.store(true, Ordering::SeqCst);
+    h.monitor.sweep_now().await;
+    assert_eq!(
+        recv_timeout(&mut h.removed_rx, "removal").await,
+        alice.key()
+    );
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// One membership query serves every participant of a Matrix room, across
+/// users, devices and slots; only the users who left are removed.
+#[tokio::test]
+async fn one_membership_query_per_room() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[BOB]),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice_1 = registration(ROOM_A, ALICE, "m.call#", "m1");
+    let alice_2 = registration(ROOM_A, ALICE, "m.call#other", "m2");
+    let bob = registration(ROOM_A, BOB, "m.call#", "m3");
+    for reg in [&alice_1, &alice_2, &bob] {
+        register_connected(&h.monitor, reg).await;
+    }
+
+    h.monitor.sweep_now().await;
+
+    assert_eq!(
+        h.joined_members_calls.lock().unwrap().as_slice(),
+        [ROOM_A.to_owned()],
+        "expected exactly one membership query for the room"
+    );
+    let removed = HashSet::from([
+        recv_timeout(&mut h.removed_rx, "first removal").await,
+        recv_timeout(&mut h.removed_rx, "second removal").await,
+    ]);
+    assert_eq!(removed, HashSet::from([alice_1.key(), alice_2.key()]));
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([bob.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// Rooms are queried independently: a user who left one room keeps their
+/// participation in another.
+#[tokio::test]
+async fn rooms_are_independent() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: Some(Box::new(|room_id| {
+                Ok(if room_id == ROOM_A {
+                    HashSet::new()
+                } else {
+                    HashSet::from([ALICE.to_owned()])
+                })
+            })),
+            ..Default::default()
+        },
+        None,
+    );
+    let in_a = registration(ROOM_A, ALICE, "m.call#", "m1");
+    let in_b = registration(ROOM_B, ALICE, "m.call#", "m2");
+    register_connected(&h.monitor, &in_a).await;
+    register_connected(&h.monitor, &in_b).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_eq!(recv_timeout(&mut h.removed_rx, "removal").await, in_a.key());
+    assert_quiet(&mut h.removed_rx, "second removal").await;
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([in_b.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+// ── the homeserver leaving ───────────────────────────────────────────────────
+
+/// Once the homeserver has left a room — the membership query is refused
+/// and MSC4502 confirms the server is gone — every LiveKit room of that
+/// Matrix room is deleted and all of its participants, pending ones
+/// included, are dropped and revoked.
+#[tokio::test]
+async fn server_left_deletes_livekit_rooms() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: not_in_room(),
+            is_server_joined_fn: server_joined(false),
+            participant_exists_fn: Some(Box::new(|_, _| Ok(false))),
+            ..Default::default()
+        },
+        None,
+    );
+    let bob_1 = registration(ROOM_A, BOB, "m.call#", "m1");
+    let bob_2 = registration(ROOM_A, BOB, "m.call#other", "m2");
+    let pending = registration(ROOM_A, ALICE, "m.call#", "m3");
+    let elsewhere = registration(ROOM_B, ALICE, "m.call#", "m4");
+    register_connected(&h.monitor, &bob_1).await;
+    register_connected(&h.monitor, &bob_2).await;
+    h.monitor.register(pending.clone()).await;
+    h.monitor.register(elsewhere.clone()).await;
+
+    h.monitor.sweep_now().await;
+
+    let deleted = HashSet::from([
+        recv_timeout(&mut h.deleted_rx, "first room deletion").await,
+        recv_timeout(&mut h.deleted_rx, "second room deletion").await,
+    ]);
+    assert_eq!(
+        deleted,
+        HashSet::from([bob_1.livekit_room.clone(), bob_2.livekit_room.clone()])
+    );
+    assert_quiet(&mut h.removed_rx, "individual removal").await;
+
+    let mut revoked = HashSet::new();
+    for _ in 0..3 {
+        revoked.insert(recv_bounded_timeout(&mut h.revoked_rx, "revocation").await);
+    }
+    assert_eq!(
+        revoked,
+        HashSet::from([bob_1.key(), bob_2.key(), pending.key()])
+    );
+
+    // Room B was also refused, so its LiveKit room goes too.
+    assert_eq!(
+        recv_timeout(&mut h.deleted_rx, "third room deletion").await,
+        elsewhere.livekit_room
+    );
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// A refused membership query while the homeserver is still in the room is
+/// a misconfiguration, not a departure: nothing is removed.
+#[tokio::test]
+async fn refusal_with_server_joined_fails_open() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: not_in_room(),
+            is_server_joined_fn: server_joined(true),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    assert_quiet(&mut h.deleted_rx, "room deletion").await;
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([alice.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// A refused membership query whose confirmation fails leaves the room
+/// alone as well.
+#[tokio::test]
+async fn refusal_with_unverifiable_server_membership_fails_open() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: not_in_room(),
+            is_server_joined_fn: Some(Box::new(|_, _| Err("boom".into()))),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    assert_quiet(&mut h.deleted_rx, "room deletion").await;
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([alice.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+// ── failing open ──────────────────────────────────────────────────────────────
+
+/// A homeserver that cannot answer the membership query leaves everyone
+/// connected.
+#[tokio::test]
+async fn homeserver_error_fails_open() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: Some(Box::new(|_| {
+                Err(MembershipQueryError::Other("503".into()))
+            })),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([alice.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// Without a resolvable Client-Server API no membership query is even
+/// attempted and everyone stays.
+#[tokio::test]
+async fn unresolvable_cs_api_fails_open() {
+    let mut h = new_harness_with(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            ..Default::default()
+        },
+        None,
+        Duration::from_secs(60 * 60),
+        failing_lookup(),
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.sweep_now().await;
+
+    assert!(h.joined_members_calls.lock().unwrap().is_empty());
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([alice.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+// ── webhook bookkeeping ───────────────────────────────────────────────────────
+
+/// A participant who left the SFU is no longer tracked, so a later loss of
+/// membership has nothing to act on.
+#[tokio::test]
+async fn participant_left_stops_tracking() {
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            ..Default::default()
+        },
+        None,
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+    h.monitor
+        .notify_sfu_event(SfuEvent::ParticipantLeft(alice.key()))
+        .await;
+
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.monitor.sweep_now().await;
+    assert!(h.joined_members_calls.lock().unwrap().is_empty());
+    assert_quiet(&mut h.removed_rx, "removal").await;
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// A finished LiveKit room takes its participants with it, and only them.
+#[tokio::test]
+async fn room_finished_stops_tracking_that_room_only() {
+    let h = new_harness(MonitorTestDeps::default(), None);
+    let in_slot_1 = registration(ROOM_A, ALICE, "m.call#", "m1");
+    let in_slot_2 = registration(ROOM_A, BOB, "m.call#other", "m2");
+    register_connected(&h.monitor, &in_slot_1).await;
+    register_connected(&h.monitor, &in_slot_2).await;
+
+    h.monitor
+        .notify_sfu_event(SfuEvent::RoomFinished(in_slot_1.livekit_room.clone()))
+        .await;
+
+    assert_eq!(
+        keys(&h.monitor.snapshot().await),
+        HashSet::from([in_slot_2.key()])
+    );
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// Connect events for participants the monitor never heard of are ignored.
+#[tokio::test]
+async fn untracked_join_is_ignored() {
+    let h = new_harness(MonitorTestDeps::default(), None);
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+
+    h.monitor
+        .notify_sfu_event(SfuEvent::ParticipantJoined(alice.key()))
+        .await;
+
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// Re-minting a token for a connected participant keeps them connected.
+#[tokio::test]
+async fn re_registration_keeps_connected_state() {
+    let h = new_harness(MonitorTestDeps::default(), None);
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor.register(alice.clone()).await;
+
+    let snapshot = h.monitor.snapshot().await;
+    assert_eq!(snapshot.len(), 1);
+    assert!(snapshot[0].connected);
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+// ── apply_sweep_outcome ───────────────────────────────────────────────────────
+
+fn tracked(
+    reg: &Registration,
+    connected: bool,
+    registered_at: DateTime<Utc>,
+) -> TrackedParticipant {
+    TrackedParticipant {
+        stored: StoredParticipant {
+            matrix_room_id: reg.matrix_room_id.clone(),
+            matrix_user_id: reg.matrix_user_id.clone(),
+            livekit_room: reg.livekit_room.clone(),
+            livekit_identity: reg.livekit_identity.clone(),
+            registered_at,
+        },
+        connected,
+    }
+}
+
+/// A pending participant confirmed absent from the SFU is forgotten once
+/// their token has expired, and kept while it is still valid. Connected
+/// participants are never expired this way.
+#[test]
+fn absent_pending_participants_expire_with_their_token() {
+    let now = Utc::now();
+    let ttl = chrono::Duration::from_std(PENDING_TTL).unwrap();
+    let old = registration(ROOM_A, ALICE, "m.call#", "old");
+    let young = registration(ROOM_A, ALICE, "m.call#", "young");
+    let connected = registration(ROOM_A, ALICE, "m.call#", "connected");
+    let mut participants = HashMap::from([
+        (old.key(), tracked(&old, false, now - ttl)),
+        (young.key(), tracked(&young, false, now - ttl / 2)),
+        (connected.key(), tracked(&connected, true, now - ttl * 2)),
+    ]);
+
+    let actions = apply_sweep_outcome(
+        &mut participants,
+        SweepOutcome {
+            present: vec![],
+            absent: vec![old.key(), young.key(), connected.key()],
+            rooms: vec![(ROOM_A.into(), RoomMembership::Unknown)],
+        },
+        now,
+    );
+
+    assert_eq!(
+        actions,
+        SweepActions {
+            forgotten: vec![old.key()],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        participants.keys().cloned().collect::<HashSet<_>>(),
+        HashSet::from([young.key(), connected.key()])
+    );
+}
+
+/// Presence learnt in the same sweep counts for the kick decision, and a
+/// pending non-member is not kicked.
+#[test]
+fn presence_learnt_in_sweep_enables_kick() {
+    let now = Utc::now();
+    let seen = registration(ROOM_A, ALICE, "m.call#", "seen");
+    let unseen = registration(ROOM_A, ALICE, "m.call#", "unseen");
+    let mut participants = HashMap::from([
+        (seen.key(), tracked(&seen, false, now)),
+        (unseen.key(), tracked(&unseen, false, now)),
+    ]);
+
+    let actions = apply_sweep_outcome(
+        &mut participants,
+        SweepOutcome {
+            present: vec![seen.key()],
+            absent: vec![unseen.key()],
+            rooms: vec![(ROOM_A.into(), RoomMembership::Joined(HashSet::new()))],
+        },
+        now,
+    );
+
+    assert_eq!(
+        actions,
+        SweepActions {
+            kick: vec![seen.key()],
+            revoked: vec![seen.key()],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        participants.keys().cloned().collect::<HashSet<_>>(),
+        HashSet::from([unseen.key()])
+    );
+}
+
+/// The sweep input covers every Matrix room once and lists exactly the
+/// pending participants.
+#[test]
+fn sweep_input_is_deduplicated() {
+    let now = Utc::now();
+    let a1 = registration(ROOM_A, ALICE, "m.call#", "m1");
+    let a2 = registration(ROOM_A, BOB, "m.call#", "m2");
+    let b = registration(ROOM_B, ALICE, "m.call#", "m3");
+    let participants = HashMap::from([
+        (a1.key(), tracked(&a1, true, now)),
+        (a2.key(), tracked(&a2, false, now)),
+        (b.key(), tracked(&b, false, now)),
+    ]);
+
+    let input = SweepInput::from_participants(&participants);
+
+    assert_eq!(input.rooms, vec![ROOM_A.to_owned(), ROOM_B.to_owned()]);
+    assert_eq!(
+        input.pending.into_iter().collect::<HashSet<_>>(),
+        HashSet::from([a2.key(), b.key()])
+    );
+}
+
+// ── persistence ───────────────────────────────────────────────────────────────
+
+/// Registrations are persisted and recovered by a fresh monitor, which then
+/// verifies them against the SFU and enforces membership as usual. Kicked
+/// participants are removed from the store.
+#[tokio::test]
+async fn participants_are_persisted_and_recovered() {
+    let store = new_in_memory_store();
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+
+    {
+        let h = new_harness(MonitorTestDeps::default(), Some(store.clone()));
+        register_connected(&h.monitor, &alice).await;
+        // Make sure the registration was processed before shutting down.
+        assert_eq!(h.monitor.snapshot().await.len(), 1);
+        h.cancel.cancel();
+        h.monitor.close().await;
+    }
+    let stored = store.all_participants().await.unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].key(), alice.key());
+    assert_eq!(stored[0].matrix_room_id, ROOM_A);
+    assert_eq!(stored[0].matrix_user_id, ALICE);
+
+    let mut h = new_harness(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            ..Default::default()
+        },
+        Some(store.clone()),
+    );
+    let mut recovered = h.monitor.recovery_done();
+    while !*recovered.borrow_and_update() {
+        recovered.changed().await.unwrap();
+    }
+
+    // Recovery triggers a sweep of its own; with the participant present on
+    // the SFU (the deps' default) and no longer a member, they are kicked.
+    assert_eq!(
+        recv_timeout(&mut h.removed_rx, "removal").await,
+        alice.key()
+    );
+    assert_eq!(
+        recv_bounded_timeout(&mut h.revoked_rx, "revocation").await,
+        alice.key()
+    );
+    h.monitor.sweep_now().await; // Flushes the store writer's queue.
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.cancel.cancel();
+    h.monitor.close().await;
+    assert!(store.all_participants().await.unwrap().is_empty());
+}
+
+/// Participants that leave the SFU are removed from the store too.
+#[tokio::test]
+async fn departed_participants_are_removed_from_the_store() {
+    let store = new_in_memory_store();
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    let h = new_harness(MonitorTestDeps::default(), Some(store.clone()));
+    register_connected(&h.monitor, &alice).await;
+
+    h.monitor
+        .notify_sfu_event(SfuEvent::ParticipantLeft(alice.key()))
+        .await;
+    // The snapshot round-trip guarantees the leave has been processed (and
+    // its store delete queued) before the loop is shut down; `close` then
+    // lets the store writer drain.
+    assert!(h.monitor.snapshot().await.is_empty());
+    h.cancel.cancel();
+    h.monitor.close().await;
+
+    assert!(store.all_participants().await.unwrap().is_empty());
+}
+
+// ── schedule ──────────────────────────────────────────────────────────────────
+
+/// Sweeps run on the configured interval without being asked.
+#[tokio::test(start_paused = true)]
+async fn sweeps_run_periodically() {
+    let mut h = new_harness_with(
+        MonitorTestDeps {
+            get_joined_members_fn: members(&[]),
+            ..Default::default()
+        },
+        None,
+        Duration::from_secs(10),
+        resolving_lookup(),
+    );
+    let alice = registration(ROOM_A, ALICE, "m.call#", "m1");
+    register_connected(&h.monitor, &alice).await;
+
+    // Paused time auto-advances to the next timer once everything is idle,
+    // so this resolves as soon as the first tick has fired and been acted on.
+    let removed = tokio::time::timeout(Duration::from_secs(60), h.removed_rx.recv())
+        .await
+        .expect("expected the periodic sweep to kick the participant")
+        .expect("channel closed");
+    assert_eq!(removed, alice.key());
+    h.cancel.cancel();
+    h.monitor.close().await;
+}
+
+/// Cancelling the parent token shuts the monitor down; `close` waits for it.
+#[tokio::test]
+async fn close_after_parent_cancellation() {
+    let h = new_harness(MonitorTestDeps::default(), None);
+    h.cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(5), h.monitor.close())
+        .await
+        .expect("close should return promptly");
+    // Messages after shutdown are dropped rather than blocking.
+    h.monitor
+        .register(registration(ROOM_A, ALICE, "m.call#", "m1"))
+        .await;
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use crate::delayed_event_manager::{DelayedEventJobParams, JobKey};
+use crate::helper::{LiveKitIdentity, LiveKitRoomAlias, ParticipantKey};
 
 /// A stored job.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -26,6 +27,33 @@ pub struct StoredJob {
     pub params: DelayedEventJobParams,
     #[serde(rename = "RestartedAt")]
     pub restarted_at: DateTime<Utc>,
+}
+
+/// An SFU participant the service issued a token for, together with the
+/// Matrix room membership that entitles them to it. Persisted so that
+/// membership enforcement picks up where it left off after a restart.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoredParticipant {
+    /// The Matrix room the token was issued for.
+    pub matrix_room_id: String,
+    /// The Matrix user the token was issued to.
+    pub matrix_user_id: String,
+    /// The LiveKit room the token grants access to.
+    pub livekit_room: LiveKitRoomAlias,
+    /// The LiveKit identity the token was issued for.
+    pub livekit_identity: LiveKitIdentity,
+    /// When the token was issued.
+    pub registered_at: DateTime<Utc>,
+}
+
+impl StoredParticipant {
+    /// The key this participant is stored under.
+    pub fn key(&self) -> ParticipantKey {
+        ParticipantKey {
+            room: self.livekit_room.clone(),
+            identity: self.livekit_identity.clone(),
+        }
+    }
 }
 
 /// Interface for storage backends.
@@ -44,6 +72,21 @@ pub trait Store: Send + Sync {
 
     /// Retrieves all jobs in the store.
     async fn all_jobs(&self) -> Result<Vec<StoredJob>, String>;
+
+    /// Adds a participant to the store, overwriting any existing entry for
+    /// the same key.
+    async fn save_participant(
+        &self,
+        key: &ParticipantKey,
+        participant: &StoredParticipant,
+    ) -> Result<(), String>;
+
+    /// Removes the participant stored under the given key. A missing entry
+    /// is not an error.
+    async fn delete_participant(&self, key: &ParticipantKey) -> Result<(), String>;
+
+    /// Retrieves all participants in the store.
+    async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String>;
 }
 
 /// A store backend using an external Redis instance.
@@ -53,6 +96,7 @@ pub struct RedisStore {
 }
 
 pub(crate) const REDIS_JOBS_HASH_KEY: &str = "lk-jwt:jobs";
+pub(crate) const REDIS_PARTICIPANTS_HASH_KEY: &str = "lk-jwt:participants";
 
 pub async fn new_redis_store(redis_url: &str) -> Result<Arc<dyn Store>, String> {
     let client = redis::Client::open(redis_url)
@@ -76,20 +120,24 @@ impl RedisStore {
         Self { conn }
     }
 
-    fn key_to_string(key: &JobKey) -> String {
+    fn key_to_string(key: &ParticipantKey) -> String {
         serde_json::to_string(&[key.room.as_str(), key.identity.as_str()])
             .expect("string slices always serialize")
     }
-}
 
-#[async_trait]
-impl Store for RedisStore {
-    async fn save_job(&self, key: &JobKey, job: &StoredJob) -> Result<(), String> {
-        let data = serde_json::to_string(job)
-            .map_err(|e| format!("store: failed marshalling job: {e}"))?;
+    /// Stores `value` under `key` in the given hash.
+    async fn hset<T: Serialize>(
+        &self,
+        hash_key: &str,
+        key: &ParticipantKey,
+        value: &T,
+        what: &str,
+    ) -> Result<(), String> {
+        let data = serde_json::to_string(value)
+            .map_err(|e| format!("store: failed marshalling {what}: {e}"))?;
         let mut conn = self.conn.clone();
         redis::cmd("HSET")
-            .arg(REDIS_JOBS_HASH_KEY)
+            .arg(hash_key)
             .arg(Self::key_to_string(key))
             .arg(data)
             .query_async::<()>(&mut conn)
@@ -97,34 +145,72 @@ impl Store for RedisStore {
             .map_err(|e| e.to_string())
     }
 
-    async fn delete_job(&self, key: &JobKey) -> Result<(), String> {
+    /// Removes `key` from the given hash.
+    async fn hdel(&self, hash_key: &str, key: &ParticipantKey) -> Result<(), String> {
         let mut conn = self.conn.clone();
         redis::cmd("HDEL")
-            .arg(REDIS_JOBS_HASH_KEY)
+            .arg(hash_key)
             .arg(Self::key_to_string(key))
             .query_async::<()>(&mut conn)
             .await
             .map_err(|e| e.to_string())
     }
 
-    async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
+    /// Loads every parseable entry of the given hash, skipping (and logging)
+    /// the rest.
+    async fn hgetall<T: for<'de> Deserialize<'de>>(
+        &self,
+        hash_key: &str,
+    ) -> Result<Vec<T>, String> {
         let mut conn = self.conn.clone();
         let fields: std::collections::HashMap<String, String> = redis::cmd("HGETALL")
-            .arg(REDIS_JOBS_HASH_KEY)
+            .arg(hash_key)
             .query_async(&mut conn)
             .await
             .map_err(|e| format!("store: failed getting all entries: {e}"))?;
 
-        let mut jobs = Vec::with_capacity(fields.len());
+        let mut entries = Vec::with_capacity(fields.len());
         for (identity, data) in fields {
-            match serde_json::from_str::<StoredJob>(&data) {
-                Ok(job) => jobs.push(job),
+            match serde_json::from_str::<T>(&data) {
+                Ok(entry) => entries.push(entry),
                 Err(err) => {
-                    warn!(identity, err = %err, "store: skipping unparseable entry");
+                    warn!(hash_key, identity, err = %err, "store: skipping unparseable entry");
                 }
             }
         }
-        Ok(jobs)
+        Ok(entries)
+    }
+}
+
+#[async_trait]
+impl Store for RedisStore {
+    async fn save_job(&self, key: &JobKey, job: &StoredJob) -> Result<(), String> {
+        self.hset(REDIS_JOBS_HASH_KEY, key, job, "job").await
+    }
+
+    async fn delete_job(&self, key: &JobKey) -> Result<(), String> {
+        self.hdel(REDIS_JOBS_HASH_KEY, key).await
+    }
+
+    async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
+        self.hgetall(REDIS_JOBS_HASH_KEY).await
+    }
+
+    async fn save_participant(
+        &self,
+        key: &ParticipantKey,
+        participant: &StoredParticipant,
+    ) -> Result<(), String> {
+        self.hset(REDIS_PARTICIPANTS_HASH_KEY, key, participant, "participant")
+            .await
+    }
+
+    async fn delete_participant(&self, key: &ParticipantKey) -> Result<(), String> {
+        self.hdel(REDIS_PARTICIPANTS_HASH_KEY, key).await
+    }
+
+    async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String> {
+        self.hgetall(REDIS_PARTICIPANTS_HASH_KEY).await
     }
 }
 
@@ -145,12 +231,14 @@ pub(crate) mod test_support {
     /// An in-memory storage backend without persistence.
     pub(crate) struct InMemoryStore {
         jobs: Mutex<HashMap<JobKey, StoredJob>>,
+        participants: Mutex<HashMap<ParticipantKey, StoredParticipant>>,
     }
 
     pub(crate) fn new_in_memory_store() -> Arc<dyn Store> {
         info!("store: created new in-memory store");
         Arc::new(InMemoryStore {
             jobs: Mutex::new(HashMap::new()),
+            participants: Mutex::new(HashMap::new()),
         })
     }
 
@@ -169,13 +257,49 @@ pub(crate) mod test_support {
         async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
             Ok(self.jobs.lock().unwrap().values().cloned().collect())
         }
+
+        async fn save_participant(
+            &self,
+            key: &ParticipantKey,
+            participant: &StoredParticipant,
+        ) -> Result<(), String> {
+            self.participants
+                .lock()
+                .unwrap()
+                .insert(key.clone(), participant.clone());
+            Ok(())
+        }
+
+        async fn delete_participant(&self, key: &ParticipantKey) -> Result<(), String> {
+            self.participants.lock().unwrap().remove(key);
+            Ok(())
+        }
+
+        async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String> {
+            Ok(self
+                .participants
+                .lock()
+                .unwrap()
+                .values()
+                .cloned()
+                .collect())
+        }
     }
 
-    /// An in-memory store that notifies about job save and deletion.
+    /// An in-memory store that notifies about job save and deletion, and
+    /// about participant save and deletion.
     pub(crate) struct NotifyingStore {
         inner: Arc<dyn Store>,
         saved_tx: mpsc::Sender<JobKey>,
         deleted_tx: mpsc::Sender<JobKey>,
+        participant_saved_tx: mpsc::Sender<ParticipantKey>,
+        participant_deleted_tx: mpsc::Sender<ParticipantKey>,
+    }
+
+    /// The receiving ends of a [`NotifyingStore`]'s participant notifications.
+    pub(crate) struct ParticipantNotifications {
+        pub saved_rx: mpsc::Receiver<ParticipantKey>,
+        pub deleted_rx: mpsc::Receiver<ParticipantKey>,
     }
 
     pub(crate) fn new_notifying_store() -> (
@@ -183,16 +307,34 @@ pub(crate) mod test_support {
         mpsc::Receiver<JobKey>,
         mpsc::Receiver<JobKey>,
     ) {
+        let (store, saved_rx, deleted_rx, _) = new_notifying_store_with_participants();
+        (store, saved_rx, deleted_rx)
+    }
+
+    pub(crate) fn new_notifying_store_with_participants() -> (
+        Arc<NotifyingStore>,
+        mpsc::Receiver<JobKey>,
+        mpsc::Receiver<JobKey>,
+        ParticipantNotifications,
+    ) {
         let (saved_tx, saved_rx) = mpsc::channel(10);
         let (deleted_tx, deleted_rx) = mpsc::channel(10);
+        let (participant_saved_tx, participant_saved_rx) = mpsc::channel(10);
+        let (participant_deleted_tx, participant_deleted_rx) = mpsc::channel(10);
         (
             Arc::new(NotifyingStore {
                 inner: new_in_memory_store(),
                 saved_tx,
                 deleted_tx,
+                participant_saved_tx,
+                participant_deleted_tx,
             }),
             saved_rx,
             deleted_rx,
+            ParticipantNotifications {
+                saved_rx: participant_saved_rx,
+                deleted_rx: participant_deleted_rx,
+            },
         )
     }
 
@@ -213,9 +355,29 @@ pub(crate) mod test_support {
         async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
             self.inner.all_jobs().await
         }
+
+        async fn save_participant(
+            &self,
+            key: &ParticipantKey,
+            participant: &StoredParticipant,
+        ) -> Result<(), String> {
+            self.inner.save_participant(key, participant).await?;
+            let _ = self.participant_saved_tx.send(key.clone()).await;
+            Ok(())
+        }
+
+        async fn delete_participant(&self, key: &ParticipantKey) -> Result<(), String> {
+            self.inner.delete_participant(key).await?;
+            let _ = self.participant_deleted_tx.send(key.clone()).await;
+            Ok(())
+        }
+
+        async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String> {
+            self.inner.all_participants().await
+        }
     }
 
-    /// A store whose saves block until the gate receives permits.
+    /// A store whose job saves block until the gate receives permits.
     pub(crate) struct GatedStore {
         inner: Arc<dyn Store>,
         gate: Arc<tokio::sync::Semaphore>,
@@ -241,6 +403,22 @@ pub(crate) mod test_support {
         async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
             self.inner.all_jobs().await
         }
+
+        async fn save_participant(
+            &self,
+            key: &ParticipantKey,
+            participant: &StoredParticipant,
+        ) -> Result<(), String> {
+            self.inner.save_participant(key, participant).await
+        }
+
+        async fn delete_participant(&self, key: &ParticipantKey) -> Result<(), String> {
+            self.inner.delete_participant(key).await
+        }
+
+        async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String> {
+            self.inner.all_participants().await
+        }
     }
 
     /// A store that fails on any operation.
@@ -257,6 +435,22 @@ pub(crate) mod test_support {
         }
 
         async fn all_jobs(&self) -> Result<Vec<StoredJob>, String> {
+            Err("failed".into())
+        }
+
+        async fn save_participant(
+            &self,
+            _key: &ParticipantKey,
+            _participant: &StoredParticipant,
+        ) -> Result<(), String> {
+            Err("failed".into())
+        }
+
+        async fn delete_participant(&self, _key: &ParticipantKey) -> Result<(), String> {
+            Err("failed".into())
+        }
+
+        async fn all_participants(&self) -> Result<Vec<StoredParticipant>, String> {
             Err("failed".into())
         }
     }
@@ -518,6 +712,109 @@ mod tests {
                 .delete_job(&key)
                 .await
                 .expect("deleting missing job failed");
+        }
+
+        // ── participants ─────────────────────────────────────────────────────
+
+        let participant = StoredParticipant {
+            matrix_room_id: "!room:example.com".into(),
+            matrix_user_id: "@user:example.com".into(),
+            livekit_room: room.clone(),
+            livekit_identity: identity.clone(),
+            registered_at: Utc::now().trunc_subsecs(3),
+        };
+        let participant_key = participant.key();
+
+        // Participants and jobs live side by side without interfering.
+        {
+            let store = new_store().await;
+            store.save_job(&key, &job).await.expect("saving job failed");
+
+            assert!(
+                store
+                    .all_participants()
+                    .await
+                    .expect("getting all participants failed")
+                    .is_empty(),
+                "expected no participants on a store holding only a job"
+            );
+
+            store
+                .save_participant(&participant_key, &participant)
+                .await
+                .expect("saving participant failed");
+            let participants = store
+                .all_participants()
+                .await
+                .expect("getting all participants failed");
+            assert_eq!(participants, vec![participant.clone()]);
+            assert_eq!(
+                store.all_jobs().await.expect("getting all jobs failed"),
+                vec![job.clone()],
+                "expected the job to be untouched by participant writes"
+            );
+        }
+
+        // Saving a participant under an existing key overwrites it.
+        {
+            let store = new_store().await;
+            store
+                .save_participant(&participant_key, &participant)
+                .await
+                .expect("saving first participant failed");
+
+            let mut updated = participant.clone();
+            updated.matrix_room_id = "!other:example.com".into();
+            store
+                .save_participant(&participant_key, &updated)
+                .await
+                .expect("saving second participant failed");
+
+            let participants = store
+                .all_participants()
+                .await
+                .expect("getting all participants failed");
+            assert_eq!(participants, vec![updated]);
+        }
+
+        // Deleting a participant leaves the others in place; deleting a
+        // missing one is not an error.
+        {
+            let store = new_store().await;
+            store
+                .save_participant(&participant_key, &participant)
+                .await
+                .expect("saving first participant failed");
+
+            let mut other = participant.clone();
+            other.livekit_identity = LiveKitIdentity("@other:example.com".into());
+            store
+                .save_participant(&other.key(), &other)
+                .await
+                .expect("saving second participant failed");
+
+            store
+                .delete_participant(&participant_key)
+                .await
+                .expect("deleting first participant failed");
+            store
+                .delete_participant(&participant_key)
+                .await
+                .expect("deleting the participant again failed");
+
+            let participants = store
+                .all_participants()
+                .await
+                .expect("getting all participants failed");
+            assert_eq!(participants, vec![other]);
+            assert!(
+                store
+                    .all_jobs()
+                    .await
+                    .expect("getting all jobs failed")
+                    .is_empty(),
+                "expected participant writes not to create jobs"
+            );
         }
     }
 


### PR DESCRIPTION
This pull request implements kicking SFU participants when the associated Matrix user leaves the Matrix room as RECOMMENDED in [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).

This is achieved by tracking all participants the service issues a token for and, every `LIVEKIT_MEMBERSHIP_CHECK_INTERVAL_SECONDS`, reconciling them against the homeserver:

- One `GET /rooms/{roomId}/joined_members` request is made per Matrix room with tracked participants. Connected participants whose user is no longer joined are removed from the LiveKit room. Participants who were issued a token but never connected to the SFU are left alone until they do.
- Once the homeserver has no local user left in a room, it refuses that request. The service confirms the homeserver's departure via `/is_joined` and then deletes the room's LiveKit rooms outright: only local users can publish on this SFU, so nothing legitimate is left in them. A refusal while the homeserver is still in the room points at a `users` namespace that doesn't match the homeserver's local users and is logged as an error; nothing is removed in that case.
- Any other failure to determine membership leaves the participants untouched, so a homeserver outage never drops calls.

Tracked participants are persisted in the Redis store, if configured, so that enforcement resumes after a restart. Note that this doesn't obsolete short-lived access tokens: a participant is only ever removed at the next check, up to one interval after losing their membership.

The end-to-end tests in the `e2e-tests` folder prove that the process is working correctly.

The polling architecture this pull request uses has drawbacks. The service needs to proactively poll the homeserver on an interval which causes load. Ideally, the homeserver would instead push leaves to the service. This would require changes in Synapse and (likely) a new MSC, however. The polling approach here was, therefore, chosen as a practical alternative. The general procedure for tracking and removing active participants would be the same in both variants.